### PR TITLE
Make given and should optional

### DIFF
--- a/build/tested.lua
+++ b/build/tested.lua
@@ -27,11 +27,12 @@ end
 
 function tested.assert(assertion)
    local errors = {}
-   if assertion.given == nil then table.insert(errors, "'given'") end
-   if assertion.should == nil then table.insert(errors, "'should'") end
    if assertion.expected == nil then table.insert(errors, "'expected'") end
    if assertion.actual == nil then table.insert(errors, "'actual'") end
-   assert(#errors == 0, "The assertion table must include 'given', 'should', 'expected', and 'actual'. Missing: " .. table.concat(errors, ", "))
+   assert(#errors == 0, "The assertion table must include 'expected' and 'actual'. Missing: " .. table.concat(errors, ", "))
+   if assertion.given and type(assertion.given) ~= "string" then table.insert(errors, "In assertion, 'should' should be a 'string'. It appears to be a '" .. type(assertion.should) .. "'") end
+   if assertion.should and type(assertion.should) ~= "string" then table.insert(errors, "In assertion, 'given' should be a 'string'. It appears to be a '" .. type(assertion.should) .. "'") end
+   assert(#errors == 0, table.concat(errors, ". "))
    local expected_type = type(assertion.expected)
    local actual_type = type(assertion.actual)
 

--- a/build/tested/display.lua
+++ b/build/tested/display.lua
@@ -1,4 +1,4 @@
-local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = true, require('compat53.module'); if p then _tl_compat = m end end; local ipairs = _tl_compat and _tl_compat.ipairs or ipairs; local string = _tl_compat and _tl_compat.string or string; local table = _tl_compat and _tl_compat.table or table
+
 
 
 local symbol_map = {
@@ -26,6 +26,22 @@ local function to_ms(time_s)
    end
 end
 
+local function format_assertion_result(assertion_result)
+   local output = "  " .. symbol_map[assertion_result.result] .. " " .. assertion_result.filename .. ":" .. assertion_result.line_number
+
+   if assertion_result.given then
+      output = output .. " - Given: " .. assertion_result.given
+      if assertion_result.should then
+         output = output .. "  Should: " .. assertion_result.should
+      end
+
+
+   elseif assertion_result.should then
+      output = output .. " - Should: " .. assertion_result.should
+   end
+   return output
+end
+
 function display.results(tested_result, test_types_to_display)
    print("- " .. tested_result.module_name .. " (" .. to_ms(tested_result.total_time) .. ")")
    for _, test_result in ipairs(tested_result.tests) do
@@ -37,8 +53,7 @@ function display.results(tested_result, test_types_to_display)
          if test_result.result == "FAIL" or test_result.result == "PASS" then
             for _, assertion_result in ipairs(test_result.assertion_results) do
                if (assertion_result.result == "FAIL" and test_types_to_display["FAIL"]) or assertion_result.result == "PASS" and test_types_to_display["PASS"] then
-                  print("  " .. symbol_map[assertion_result.result] .. " " .. assertion_result.filename .. ":" .. assertion_result.line_number ..
-                  " - Given: " .. assertion_result.given .. "  Should: " .. assertion_result.should)
+                  print(format_assertion_result(assertion_result))
 
                   if assertion_result.result == "FAIL" then
                      print("      " .. assertion_result.error_message:gsub("\n", "\n      "))

--- a/src/tested.tl
+++ b/src/tested.tl
@@ -27,11 +27,12 @@ end
 
 function tested.assert<T>(assertion: types.Assertion<T>): boolean, string
     local errors = {}
-    if assertion.given == nil then table.insert(errors, "'given'") end
-    if assertion.should == nil then table.insert(errors, "'should'") end
     if assertion.expected == nil then table.insert(errors, "'expected'") end
     if assertion.actual == nil then table.insert(errors, "'actual'") end
-    assert(#errors == 0, "The assertion table must include 'given', 'should', 'expected', and 'actual'. Missing: " .. table.concat(errors, ", "))
+    assert(#errors == 0, "The assertion table must include 'expected' and 'actual'. Missing: " .. table.concat(errors, ", "))
+    if assertion.given and type(assertion.given) ~= "string" then table.insert(errors, "In assertion, 'should' should be a 'string'. It appears to be a '" .. type(assertion.should) .. "'") end
+    if assertion.should and type(assertion.should) ~= "string" then table.insert(errors, "In assertion, 'given' should be a 'string'. It appears to be a '" .. type(assertion.should) .. "'") end
+    assert(#errors == 0, table.concat(errors, ". "))
     local expected_type = type(assertion.expected)
     local actual_type = type(assertion.actual)
     

--- a/src/tested/display.tl
+++ b/src/tested/display.tl
@@ -26,6 +26,22 @@ local function to_ms(time_s: number): string
     end
 end
 
+local function format_assertion_result(assertion_result: types.AssertionResult): string
+    local output = "  " .. symbol_map[assertion_result.result] .. " " .. assertion_result.filename .. ":" .. assertion_result.line_number
+    -- given and should
+    if assertion_result.given then
+        output = output .. " - Given: " .. assertion_result.given 
+        if assertion_result.should then
+            output = output .. "  Should: " .. assertion_result.should
+        end
+
+    -- just should
+    elseif assertion_result.should then
+        output = output .. " - Should: " .. assertion_result.should
+    end
+    return output
+end
+
 function display.results(tested_result: types.TestedOutput, test_types_to_display: {types.TestResult: boolean})
     print("- " .. tested_result.module_name .. " (" .. to_ms(tested_result.total_time) .. ")")
     for _, test_result in ipairs(tested_result.tests) do
@@ -37,8 +53,7 @@ function display.results(tested_result: types.TestedOutput, test_types_to_displa
             if test_result.result == "FAIL" or test_result.result == "PASS" then
                 for _, assertion_result in ipairs(test_result.assertion_results) do
                     if (assertion_result.result == "FAIL" and test_types_to_display["FAIL"]) or assertion_result.result == "PASS" and test_types_to_display["PASS"] then
-                        print("  " .. symbol_map[assertion_result.result] .. " " .. assertion_result.filename .. ":" .. assertion_result.line_number ..
-                        " - Given: " .. assertion_result.given .. "  Should: " .. assertion_result.should)
+                        print(format_assertion_result(assertion_result))
                         
                         if assertion_result.result == "FAIL" then
                             print("      " .. assertion_result.error_message:gsub("\n", "\n      "))

--- a/tests/fully_working.lua
+++ b/tests/fully_working.lua
@@ -9,4 +9,11 @@ tested.test("just works!", function()
 	})
 end)
 
+tested.test("just works without given and should!", function()
+	tested.assert({
+		expected=true,
+		actual=true
+	})
+end)
+
 return tested

--- a/tests/non_working.tl
+++ b/tests/non_working.tl
@@ -1,0 +1,29 @@
+local tested = require("tested")
+
+tested.test("doesn't work with given and should being not strings!", function()
+	tested.assert({
+		given=true,
+		should=1,
+		expected=true,
+		actual=true
+	})
+end)
+
+
+tested.test("output should clearly show just given", function()
+	tested.assert({
+		given="true",
+		expected=false,
+		actual=true
+	})
+end)
+
+tested.test("output should clearly show just should", function()
+	tested.assert({
+		should="true",
+		expected=true,
+		actual=false
+	})
+end)
+
+return tested


### PR DESCRIPTION
What the output looks like now with the options missing:

```
- tests.non_working (0.012ms)
 ! doesn't work with given and should being not strings! (0.007ms)
      src/tested.tl:35: In assertion, 'should' should be a 'string'. It appears to be a 'number'. In assertion, 'given' should be a 'string'. It appears to be a 'number'
      stack traceback:
        src/tested/test_runner.tl:98: in function 'tested.test_runner.run'
        src/tested/test_runner.tl:150: in for iterator 'for iterator'
        src/tested/main.tl:129: in local 'main'
        src/tested/main.tl:144: in main chunk
        (...tail calls...)
        ...rce/tested/lua/lib/luarocks/rocks-5.4/tl/0.24.8-1/bin/tl:1002: in main chunk
        [C]: in ?

 ✗ output should clearly show just given (0.003ms)
   ✗ ./tests/non_working.tl:14 - Given: true
      Actual: true
      Expected: false

 ✗ output should clearly show just should (0.002ms)
   ✗ ./tests/non_working.tl:22 - Should: true
      Actual: false
      Expected: true
```

I do generally think that they are helpful to have, but will let folks decide for that on their own!