### PR TITLE
Load files instead of modules

### DIFF
--- a/build/tested/file_loader.lua
+++ b/build/tested/file_loader.lua
@@ -1,28 +1,20 @@
 local tl = require("tl")
 
 
-local function load_lua_file(_file, filepath)
-
-
-
-
-
+local function load_lua_file(filepath)
    return assert(loadfile(filepath))
 end
 
-local function load_teal_file(file, filepath)
-
-
-
-
-
-
+local function load_teal_file(filepath)
+   local file = io.open(filepath, "rb")
    local load_function, errors = tl.load(file:read("*all"), filepath)
+   file:close()
    if not load_function then error(errors) end
    return load_function
 end
 
 local FileLoader = {}
+
 
 
 
@@ -36,26 +28,21 @@ local function get_file_extension(str)
    return str:match("^.+(%..+)$")
 end
 
-function FileLoader.load_file(filepath, loading_from)
-
-
-   local file = io.open(filepath, "rb")
-   if not file then
-      local error_message = "file not found: " .. filepath
-      if loading_from then
-         error_message = "While " .. loading_from .. ", " .. error_message
-      end
-      error(error_message)
-   end
-
+function FileLoader.load_file(filepath)
    local extension = get_file_extension(filepath)
    if FileLoader.file_loader[extension] then
-      local loader = FileLoader.file_loader[extension](file, filepath)
+      local loader = FileLoader.file_loader[extension](filepath)
       return loader()
+   else
+      error("Unable to load file of type: '" .. extension .. "'. It must be registered first")
    end
 
-   file:close()
    error("No file loader found for format: " .. extension)
+end
+
+function FileLoader.register_handler(filepath)
+   local handler = FileLoader.load_file(filepath)
+   FileLoader.file_loader[handler.extension] = handler.loader
 end
 
 return FileLoader

--- a/build/tested/results/terminal.lua
+++ b/build/tested/results/terminal.lua
@@ -97,7 +97,7 @@ function terminal.summary(counts, all_fully_tested, total_time)
    table.insert(summary, "Other: %{yellow}" .. counts.skipped .. " skipped%{reset}, " .. counts.invalid .. " invalid")
 
    if all_fully_tested then
-      table.insert(summary, "\n{%green}Fully Tested!%{reset}")
+      table.insert(summary, "\n%{bright}Fully Tested!%{reset}")
    end
 
    print(colors(table.concat(summary, "\n")))

--- a/build/tested/test_runner.lua
+++ b/build/tested/test_runner.lua
@@ -17,7 +17,7 @@ local function fisher_yates_shuffle(t)
 end
 
 function TestRunner.run(filename, tested, options)
-   if options and options.randomize then
+   if options and options.random then
       math.randomseed(os.time())
       fisher_yates_shuffle(tested.tests)
    end

--- a/build/tested/types.lua
+++ b/build/tested/types.lua
@@ -93,4 +93,9 @@ local types = {}
 
 
 
+
+
+
+
+
 return types

--- a/src/tested/file_loader.tl
+++ b/src/tested/file_loader.tl
@@ -1,30 +1,22 @@
 local tl = require("tl")
--- tl.loader()
+local type types = require("tested.types")
 
-local function load_lua_file(_file: FILE, filepath: string): function(): any
-    -- local module = filepath:gsub(".lua$", "")
-    -- module = module:gsub("/", ".")
-    -- return function(): any
-    --     return require(module)
-    -- end
+local function load_lua_file(filepath: string): function(): any
     return assert(loadfile(filepath))
 end
 
-local function load_teal_file(file: FILE, filepath: string): function(): any
-    -- local module = filepath:gsub(".tl$", "")
-    -- module = module:gsub("/", ".")
-    -- return function(): any
-    --     return require(module)
-    -- end
-
+local function load_teal_file(filepath: string): function(): any
+    local file = io.open(filepath, "rb")
     local load_function, errors = tl.load(file:read("*all"), filepath)
+    file:close()
     if not load_function then error(errors) end
     return load_function
 end
 
 local record FileLoader
-    load_file: function(filepath: string, loading_from?: string): any
-    file_loader: {string: function(file: FILE, filepath: string): function()}
+    load_file: function(filepath: string): any
+    file_loader: {string: function(filepath: string): function()}
+    register_handler: function(filepath: string)
 end
 
 FileLoader.file_loader = {
@@ -36,26 +28,21 @@ local function get_file_extension(str: string): string
     return str:match("^.+(%..+)$")
 end
 
-function FileLoader.load_file(filepath: string, loading_from?: string): any
-
-    -- possibly only need this for custom formatter, might move this out of here!
-    local file = io.open(filepath, "rb")
-    if not file then
-        local error_message = "file not found: " .. filepath
-        if loading_from then
-            error_message = "While " .. loading_from .. ", " .. error_message
-        end
-        error(error_message)
-    end
-
+function FileLoader.load_file(filepath: string): any
     local extension = get_file_extension(filepath)
     if FileLoader.file_loader[extension] then
-        local loader = FileLoader.file_loader[extension](file, filepath)
+        local loader = FileLoader.file_loader[extension](filepath)
         return loader() as any
+    else
+        error("Unable to load file of type: '" .. extension .. "'. It must be registered first")
     end
 
-    file:close()
     error("No file loader found for format: " .. extension)
+end
+
+function FileLoader.register_handler(filepath: string)
+    local handler = FileLoader.load_file(filepath) as types.FileLoaderHandler
+    FileLoader.file_loader[handler.extension] = handler.loader
 end
 
 return FileLoader

--- a/src/tested/main.tl
+++ b/src/tested/main.tl
@@ -27,34 +27,44 @@ local cli_to_display: {DisplayOptions:types.TestResult} = {
     ["timeout"] = "TIMEOUT"
 }
 
+local enum DisplayFormat
+    "terminal" "plain"
+end
+
 local record CLIOptions
-    randomize: boolean
-    display: {DisplayOptions}
-    output_format: string
+    random: boolean
+    show: {DisplayOptions}
+    display_format: DisplayFormat
     custom_formatter: string
+    format_handler: {string}
     paths: {string}
+
+    -- derived from paths
     test_files: {string}
     test_directories: {string}
 end
 
 local function parse_args(): CLIOptions
     local parser = argparse("tested", "A Lua/Teal Unit Testing Framework", "For more info see https://github.com/FourierTransformer/tested")
-    parser:flag("-v --version")
+    parser:flag("--version")
         :description("Show version information")
         :action(function() print("tested v0.0.0") os.exit(0) end)
-    parser:flag("-r --randomize")
+    parser:flag("-r --random")
         :description("Randomize the order of the tests (default: not-set)")
         :default(false)
-    parser:option("-d --display")
-        :description("What test results to display (default: '-d fail -d exception -d unknown'")
+    parser:option("-s --show")
+        :description("What test results to display (default: '-s fail -s exception -s unknown')")
         :choices({"all", "valid", "invalid", "skip", "pass", "fail", "exception", "unknown", "timeout"})
         :count("*")
-    parser:option("-o --output-format")
+    parser:option("-f --display-format")
         :description("What format to output the results in (default: 'terminal')")
         :choices({"terminal", "plain"})
         :default("terminal")
-    parser:option("-f --custom-formatter")
-        :description("Custom Formatter to use for output")
+    parser:option("--custom-formatter")
+        :description("File that loads a custom formatter to use for output")
+    parser:option("--format-handler")
+        :description("File that loads custom formats that are Lua-compatible")
+        :count("*")
     parser:argument("paths", "Path(s) to directories or files with tests to run (default: 'tests')")
         :args("*")
 
@@ -63,15 +73,15 @@ local function parse_args(): CLIOptions
 end
 
 local function set_defaults(args: CLIOptions)
-    if #args.display == 0 then args.display = {"fail", "exception", "unknown", "timeout"} end
+    if #args.show == 0 then args.show = {"fail", "exception", "unknown", "timeout"} end
     -- if not args.paths then args.paths = {"./tests"} end
     if #args.paths == 0 then args.paths = {"tests"} end
     args.test_files = {}
     args.test_directories = {}
     
     local show_all = false
-    for _, display_option in ipairs(args.display) do if display_option == "all" then show_all = true break end end
-    if show_all then args.display = {"skip", "pass", "fail", "exception", "unknown", "timeout"} end
+    for _, display_option in ipairs(args.show) do if display_option == "all" then show_all = true break end end
+    if show_all then args.show = {"skip", "pass", "fail", "exception", "unknown", "timeout"} end
 end
 
 local function validate_args(args: CLIOptions)
@@ -86,7 +96,10 @@ end
 
 local function load_result_formatter(args: CLIOptions): types.ResultFormatter
     if args.custom_formatter then
-        local formatter = file_loader.load_file(args.custom_formatter, "loading a custom formatter") as types.ResultFormatter
+        local info, err = lfs.attributes(args.custom_formatter)
+        if err then error("Unable to load custom formatter, the file at '" .. args.custom_formatter .. "' does not appear to exist.") end
+        assert(info.mode == "file", "The custom formatter should point to a file, but currently appears to be a: " .. info.mode)
+        local formatter = file_loader.load_file(args.custom_formatter) as types.ResultFormatter
 
         if formatter then
             assert(formatter.header and type(formatter.header) == "function", "Custom formatter must include a 'header', 'results', and 'summary' section. Missing 'header'.")
@@ -97,7 +110,17 @@ local function load_result_formatter(args: CLIOptions): types.ResultFormatter
             error("Unable to load custom formatter from: " .. args.custom_formatter)
         end
     else
-        return require("tested.results." .. args.output_format) as types.ResultFormatter
+        return require("tested.results." .. args.display_format) as types.ResultFormatter
+    end
+end
+
+local function register_format_handler(handlers: {string})
+    for _, handler in ipairs(handlers) do
+        local info, err = lfs.attributes(handler)
+        if err then error("Unable to load format handler, the file at '" .. handler .."' does not appear to exist.") end
+        assert(info.mode == "file", "The custom format loader should point to a file, but currently appears to be a: " .. info.mode)
+
+        file_loader.register_handler(handler)
     end
 end
 
@@ -168,14 +191,17 @@ local function main()
     set_defaults(args)
     validate_args(args)
     local formatter = load_result_formatter(args)
+    if args.format_handler then
+        register_format_handler(args.format_handler)
+    end
     
     local test_files = get_all_test_files(args)
     assert(#test_files > 0, "Unable to find any tests to run in: " .. table.concat(args.paths, ", "))
     formatter.header(args.paths)
 
     local runner_output: types.TestRunnerOutput
-    for test_result, output in test_runner.run_tests(test_files, {randomize=args.randomize}) do
-        formatter.results(test_result, display_types(args.display))
+    for test_result, output in test_runner.run_tests(test_files, {random=args.random}) do
+        formatter.results(test_result, display_types(args.show))
         runner_output = output
     end
 

--- a/src/tested/results/terminal.tl
+++ b/src/tested/results/terminal.tl
@@ -97,7 +97,7 @@ function terminal.summary(counts: types.TestCounts, all_fully_tested: boolean, t
     table.insert(summary, "Other: %{yellow}" .. counts.skipped .. " skipped%{reset}, " .. counts.invalid .. " invalid")
 
     if all_fully_tested then
-        table.insert(summary, "\n{%green}Fully Tested!%{reset}")
+        table.insert(summary, "\n%{bright}Fully Tested!%{reset}")
     end
 
     print(colors(table.concat(summary, "\n")))

--- a/src/tested/test_runner.tl
+++ b/src/tested/test_runner.tl
@@ -2,7 +2,7 @@ local file_loader = require("tested.file_loader")
 local type types = require("tested.types")
 
 local interface TestRunnerOptions
-    randomize: boolean
+    random: boolean
 end
 
 local record TestRunner
@@ -17,7 +17,7 @@ local function fisher_yates_shuffle(t: {any})
 end
 
 function TestRunner.run(filename: string, tested: types.Tested, options?: TestRunnerOptions): types.TestedOutput
-    if options and options.randomize then
+    if options and options.random then
         math.randomseed(os.time())
         fisher_yates_shuffle(tested.tests)
     end

--- a/src/tested/types.tl
+++ b/src/tested/types.tl
@@ -74,6 +74,11 @@ local record types
         summary: function(counts: types.TestCounts, all_fully_tested: boolean, total_time: number)
     end
 
+    -- needed for registering new file types
+    interface FileLoaderHandler
+        extension: string
+        loader: function(filepath: string): function(): any
+    end
 
     -- needed for tested
     interface Test


### PR DESCRIPTION
## Changes
- Now loads file paths instead of modules
- Can specify folders _or files_ to run (useful if targeting a handful of tests)
- Changed some argument names around to hopefully be more clear
- Added a file loader, so folks can load their own formats (eg: moonscript, or something else)
- Only does garbage collection once, a bit of a speedup. See note below

NOTE: while testing this out, it seems the new file loading (instead of module loading) mechanism results in more things needing to be garbage collected, or for some reason it taking a lot longer. I _think_ this has to do with the changes to loading teal files (no more `tl.loader()` and using require, but actually using the `tl.load` function). The speed difference is more apparent while running the teal version of the code (ie: `tl run src/tested/main.tl`), but doesn't seem to exist after building it. I may look into it later.

closes #7, closes #10 