### PR TITLE
Small refactor to make pure-Lua mode possible

### DIFF
--- a/build/tested.lua
+++ b/build/tested.lua
@@ -91,4 +91,117 @@ function tested.assert_throws_exception(assertion)
    end
 end
 
+local function fisher_yates_shuffle(t)
+   for i = #t, 2, -1 do
+      local j = math.random(i)
+      t[i], t[j] = t[j], t[i]
+   end
+end
+
+
+function tested:run(filename, options)
+   if options and options.random then
+      math.randomseed(os.time())
+      fisher_yates_shuffle(self.tests)
+   end
+
+   if self.run_only_tests then
+      print("Only running tests with 'tested.only'")
+   end
+
+   local test_results = {
+      counts = { passed = 0, failed = 0, skipped = 0, invalid = 0 },
+      tests = {},
+      filename = filename,
+      fully_tested = false,
+      total_time = 0,
+   }
+
+   for i, test in ipairs(self.tests) do
+
+      test_results.tests[i] = { assertion_results = {}, name = test.name }
+
+      if self.run_only_tests and test.kind ~= "only" then
+         test_results.tests[i].result = "SKIP"
+         test_results.tests[i].message = "Only running 'tested.only' tests"
+         test_results.tests[i].time = 0
+         test_results.counts.skipped = test_results.counts.skipped + 1
+
+      elseif test.kind == "skip" then
+         test_results.tests[i].result = "SKIP"
+         test_results.tests[i].message = "Test marked with 'tested.skip'"
+         test_results.tests[i].time = 0
+         test_results.counts.skipped = test_results.counts.skipped + 1
+
+      elseif test.kind == "conditional_skip" then
+         test_results.tests[i].result = "CONDITIONAL_SKIP"
+         test_results.tests[i].message = "Condition in `tested.conditional_skip` returned false. Skipping test."
+         test_results.tests[i].time = 0
+         test_results.counts.skipped = test_results.counts.skipped + 1
+
+      else
+         local assert_failed_count = 0
+         local total_assertions = 0
+
+
+         local original_assert = self.assert
+         self.assert = function(assertion)
+            local ok, err = original_assert(assertion)
+
+            total_assertions = total_assertions + 1
+
+            local assertion_result = {}
+            local file_info = debug.getinfo(2, "Sl")
+            assertion_result.filename = file_info.short_src
+            assertion_result.line_number = file_info.currentline
+
+            assertion_result.given = assertion.given
+            assertion_result.should = assertion.should
+
+            if ok == false then
+               assert_failed_count = assert_failed_count + 1
+               assertion_result.result = "FAIL"
+               assertion_result.error_message = err
+            else
+               assertion_result.result = "PASS"
+            end
+            table.insert(test_results.tests[i].assertion_results, assertion_result)
+
+            return ok, err
+         end
+
+         local start = os.clock()
+         local ok, err = pcall(test.fn)
+         test_results.tests[i].time = os.clock() - start
+         test_results.total_time = test_results.total_time + test_results.tests[i].time
+         self.assert = original_assert
+
+         if ok == false then
+            test_results.tests[i].result = "EXCEPTION"
+            test_results.tests[i].message = err .. "\n" .. debug.traceback()
+            test_results.counts.invalid = test_results.counts.invalid + 1
+
+         elseif total_assertions == 0 then
+            test_results.tests[i].result = "UNKNOWN"
+            test_results.tests[i].message = "No assertions run during test"
+            test_results.counts.invalid = test_results.counts.invalid + 1
+
+         elseif assert_failed_count == 0 then
+            test_results.tests[i].result = "PASS"
+            test_results.tests[i].message = "All assertions have passed"
+            test_results.counts.passed = test_results.counts.passed + 1
+
+         else
+            test_results.tests[i].result = "FAIL"
+            test_results.tests[i].message = assert_failed_count .. " assertions have failed"
+            test_results.counts.failed = test_results.counts.failed + 1
+         end
+      end
+   end
+   if test_results.counts.failed == 0 and test_results.counts.invalid == 0 then
+      test_results.fully_tested = true
+   end
+   return test_results
+end
+
 return tested

--- a/build/tested/test_runner.lua
+++ b/build/tested/test_runner.lua
@@ -6,122 +6,6 @@ local logger = logging.get_logger("tested.test_runner")
 
 local test_runner = {}
 
-
-local function fisher_yates_shuffle(t)
-   logger:info("Shuffling tests!")
-   for i = #t, 2, -1 do
-      local j = math.random(i)
-      t[i], t[j] = t[j], t[i]
-   end
-end
-
-function test_runner.run(filename, tested, options)
-   logger:info("%s: starting test", filename)
-   if options and options.random then
-      math.randomseed(os.time())
-      fisher_yates_shuffle(tested.tests)
-   end
-
-   if tested.run_only_tests then
-      logger:warning("Only running tests with 'tested.only'")
-   end
-
-   local test_results = {
-      counts = { passed = 0, failed = 0, skipped = 0, invalid = 0 },
-      tests = {},
-      filename = filename,
-      fully_tested = false,
-      total_time = 0,
-   }
-
-   for i, test in ipairs(tested.tests) do
-
-      test_results.tests[i] = { assertion_results = {}, name = test.name }
-
-      if tested.run_only_tests and test.kind ~= "only" then
-         test_results.tests[i].result = "SKIP"
-         test_results.tests[i].message = "Only running 'tested.only' tests"
-         test_results.tests[i].time = 0
-         test_results.counts.skipped = test_results.counts.skipped + 1
-
-      elseif test.kind == "skip" then
-         test_results.tests[i].result = "SKIP"
-         test_results.tests[i].message = "Test marked with 'tested.skip'"
-         test_results.tests[i].time = 0
-         test_results.counts.skipped = test_results.counts.skipped + 1
-
-      elseif test.kind == "conditional_skip" then
-         test_results.tests[i].result = "CONDITIONAL_SKIP"
-         test_results.tests[i].message = "Condition in `tested.conditional_skip` returned false. Skipping test."
-         test_results.tests[i].time = 0
-         test_results.counts.skipped = test_results.counts.skipped + 1
-
-      else
-         local assert_failed_count = 0
-         local total_assertions = 0
-
-
-         local original_assert = tested.assert
-         tested.assert = function(assertion)
-            local ok, err = original_assert(assertion)
-
-            total_assertions = total_assertions + 1
-
-            local assertion_result = {}
-            local file_info = debug.getinfo(2, "Sl")
-            assertion_result.filename = file_info.short_src
-            assertion_result.line_number = file_info.currentline
-
-            assertion_result.given = assertion.given
-            assertion_result.should = assertion.should
-
-            if ok == false then
-               assert_failed_count = assert_failed_count + 1
-               assertion_result.result = "FAIL"
-               assertion_result.error_message = err
-            else
-               assertion_result.result = "PASS"
-            end
-            table.insert(test_results.tests[i].assertion_results, assertion_result)
-
-            return ok, err
-         end
-
-         local start = os.clock()
-         local ok, err = pcall(test.fn)
-         test_results.tests[i].time = os.clock() - start
-         test_results.total_time = test_results.total_time + test_results.tests[i].time
-         tested.assert = original_assert
-
-         if ok == false then
-            test_results.tests[i].result = "EXCEPTION"
-            test_results.tests[i].message = err .. "\n" .. debug.traceback()
-            test_results.counts.invalid = test_results.counts.invalid + 1
-
-         elseif total_assertions == 0 then
-            test_results.tests[i].result = "UNKNOWN"
-            test_results.tests[i].message = "No assertions run during test"
-            test_results.counts.invalid = test_results.counts.invalid + 1
-
-         elseif assert_failed_count == 0 then
-            test_results.tests[i].result = "PASS"
-            test_results.tests[i].message = "All assertions have passed"
-            test_results.counts.passed = test_results.counts.passed + 1
-
-         else
-            test_results.tests[i].result = "FAIL"
-            test_results.tests[i].message = assert_failed_count .. " assertions have failed"
-            test_results.counts.failed = test_results.counts.failed + 1
-         end
-      end
-   end
-   if test_results.counts.failed == 0 and test_results.counts.invalid == 0 then
-      test_results.fully_tested = true
-   end
-   logger:info("%s: completed running tests!", filename)
-   return test_results
-end
-
 function test_runner.run_with_cleanup(file_loader, test_file, options)
 
    logger:info("%s: keeping track of pre-loaded packages", test_file)
@@ -131,7 +15,7 @@ function test_runner.run_with_cleanup(file_loader, test_file, options)
    local test_module = file_loader.load_file(test_file)
    assert(type(test_module) == "table" and type(test_module.tests) == "table" and type(test_module.run_only_tests) == "boolean", "It does not appear that '" .. test_file .. "' returns the 'tested' module")
 
-   local test_results = test_runner.run(test_file, test_module, options)
+   local test_results = test_module:run(test_file, options)
 
    logger:info("%s: Clearing out any packages that were loaded", test_file)
    for package_name, _ in pairs(package.loaded) do

--- a/build/tested/types.lua
+++ b/build/tested/types.lua
@@ -127,4 +127,5 @@ local types = {}
 
 
 
+
 return types

--- a/src/tested.tl
+++ b/src/tested.tl
@@ -91,4 +91,117 @@ function tested.assert_throws_exception(assertion: types.ExceptionAssertion): bo
    end
 end
 
+local function fisher_yates_shuffle(t: {any})
+   for i = #t, 2, -1 do
+      local j = math.random(i)
+      t[i], t[j] = t[j], t[i]
+   end
+end
+
+-- moved in here for hopes of one day being able to run a test from here directly
+function tested:run(filename: string, options: types.TestRunnerOptions): types.TestedOutput
+   if options and options.random then
+      math.randomseed(os.time())
+      fisher_yates_shuffle(self.tests)
+   end
+
+   if self.run_only_tests then
+      print("Only running tests with 'tested.only'")
+   end
+
+   local test_results: types.TestedOutput = {
+      counts = {passed=0, failed=0, skipped=0, invalid=0}, 
+      tests = {}, 
+      filename = filename,
+      fully_tested = false,
+      total_time = 0
+   }
+
+   for i, test in ipairs(self.tests) do
+
+      test_results.tests[i] = {assertion_results = {}, name = test.name}
+
+      if self.run_only_tests and test.kind ~= "only" then
+         test_results.tests[i].result = "SKIP"
+         test_results.tests[i].message = "Only running 'tested.only' tests"
+         test_results.tests[i].time = 0
+         test_results.counts.skipped = test_results.counts.skipped + 1
+
+      elseif test.kind == "skip" then
+         test_results.tests[i].result = "SKIP"
+         test_results.tests[i].message = "Test marked with 'tested.skip'"
+         test_results.tests[i].time = 0
+         test_results.counts.skipped = test_results.counts.skipped + 1
+
+      elseif test.kind == "conditional_skip" then
+         test_results.tests[i].result = "CONDITIONAL_SKIP"
+         test_results.tests[i].message = "Condition in `tested.conditional_skip` returned false. Skipping test."
+         test_results.tests[i].time = 0
+         test_results.counts.skipped = test_results.counts.skipped + 1
+
+      else
+         local assert_failed_count = 0
+         local total_assertions = 0
+
+         -- wrap the original assert so we can do some handling here
+         local original_assert = self.assert
+         self.assert = function<T>(assertion: types.Assertion<T>): boolean, string
+            local ok, err = original_assert(assertion)
+
+            total_assertions = total_assertions + 1
+
+            local assertion_result: types.AssertionResult = {}
+            local file_info = debug.getinfo(2, "Sl")
+            assertion_result.filename = file_info.short_src
+            assertion_result.line_number = file_info.currentline
+
+            assertion_result.given = assertion.given
+            assertion_result.should = assertion.should
+
+            if ok == false then
+               assert_failed_count = assert_failed_count + 1
+               assertion_result.result = "FAIL"
+               assertion_result.error_message = err
+            else
+               assertion_result.result = "PASS"
+            end
+            table.insert(test_results.tests[i].assertion_results, assertion_result)
+
+            return ok, err
+         end
+
+         local start = os.clock()
+         local ok, err = pcall(test.fn) as (boolean, string)
+         test_results.tests[i].time = os.clock() - start
+         test_results.total_time = test_results.total_time + test_results.tests[i].time
+         self.assert = original_assert
+
+         if ok == false then
+            test_results.tests[i].result = "EXCEPTION"
+            test_results.tests[i].message = err .. "\n" .. debug.traceback()
+            test_results.counts.invalid = test_results.counts.invalid + 1
+
+         elseif total_assertions == 0 then
+            test_results.tests[i].result = "UNKNOWN"
+            test_results.tests[i].message = "No assertions run during test"
+            test_results.counts.invalid = test_results.counts.invalid + 1
+
+         elseif assert_failed_count == 0 then 
+            test_results.tests[i].result = "PASS"
+            test_results.tests[i].message = "All assertions have passed"
+            test_results.counts.passed = test_results.counts.passed + 1
+
+         else
+            test_results.tests[i].result = "FAIL"
+            test_results.tests[i].message = assert_failed_count .. " assertions have failed"
+            test_results.counts.failed = test_results.counts.failed + 1
+         end
+      end
+   end
+   if test_results.counts.failed == 0 and test_results.counts.invalid == 0 then
+      test_results.fully_tested = true
+   end
+   return test_results
+end
+
 return tested

--- a/src/tested/test_runner.tl
+++ b/src/tested/test_runner.tl
@@ -6,122 +6,6 @@ local logger = logging.get_logger("tested.test_runner")
 
 local record test_runner end
 
-
-local function fisher_yates_shuffle(t: {any})
-   logger:info("Shuffling tests!")
-   for i = #t, 2, -1 do
-      local j = math.random(i)
-      t[i], t[j] = t[j], t[i]
-   end
-end
-
-function test_runner.run(filename: string, tested: types.Tested, options: types.TestRunnerOptions): types.TestedOutput
-   logger:info("%s: starting test", filename)
-   if options and options.random then
-      math.randomseed(os.time())
-      fisher_yates_shuffle(tested.tests)
-   end
-
-   if tested.run_only_tests then
-      logger:warning("Only running tests with 'tested.only'")
-   end
-
-   local test_results: types.TestedOutput = {
-      counts = {passed=0, failed=0, skipped=0, invalid=0}, 
-      tests = {}, 
-      filename = filename, 
-      fully_tested = false,
-      total_time = 0
-   }
-
-   for i, test in ipairs(tested.tests) do
-
-      test_results.tests[i] = {assertion_results = {}, name = test.name}
-
-      if tested.run_only_tests and test.kind ~= "only" then
-         test_results.tests[i].result = "SKIP"
-         test_results.tests[i].message = "Only running 'tested.only' tests"
-         test_results.tests[i].time = 0
-         test_results.counts.skipped = test_results.counts.skipped + 1
-
-      elseif test.kind == "skip" then
-         test_results.tests[i].result = "SKIP"
-         test_results.tests[i].message = "Test marked with 'tested.skip'"
-         test_results.tests[i].time = 0
-         test_results.counts.skipped = test_results.counts.skipped + 1
-
-      elseif test.kind == "conditional_skip" then
-         test_results.tests[i].result = "CONDITIONAL_SKIP"
-         test_results.tests[i].message = "Condition in `tested.conditional_skip` returned false. Skipping test."
-         test_results.tests[i].time = 0
-         test_results.counts.skipped = test_results.counts.skipped + 1
-
-      else
-         local assert_failed_count = 0
-         local total_assertions = 0
-
-         -- wrap the original assert so we can do some handling here
-         local original_assert = tested.assert
-         tested.assert = function<T>(assertion: types.Assertion<T>): boolean, string
-            local ok, err = original_assert(assertion)
-
-            total_assertions = total_assertions + 1
-
-            local assertion_result: types.AssertionResult = {}
-            local file_info = debug.getinfo(2, "Sl")
-            assertion_result.filename = file_info.short_src
-            assertion_result.line_number = file_info.currentline
-
-            assertion_result.given = assertion.given
-            assertion_result.should = assertion.should
-
-            if ok == false then
-               assert_failed_count = assert_failed_count + 1
-               assertion_result.result = "FAIL"
-               assertion_result.error_message = err
-            else
-               assertion_result.result = "PASS"
-            end
-            table.insert(test_results.tests[i].assertion_results, assertion_result)
-
-            return ok, err
-         end
-
-         local start = os.clock()
-         local ok, err = pcall(test.fn) as (boolean, string)
-         test_results.tests[i].time = os.clock() - start
-         test_results.total_time = test_results.total_time + test_results.tests[i].time
-         tested.assert = original_assert
-
-         if ok == false then
-            test_results.tests[i].result = "EXCEPTION"
-            test_results.tests[i].message = err .. "\n" .. debug.traceback()
-            test_results.counts.invalid = test_results.counts.invalid + 1
-
-         elseif total_assertions == 0 then
-            test_results.tests[i].result = "UNKNOWN"
-            test_results.tests[i].message = "No assertions run during test"
-            test_results.counts.invalid = test_results.counts.invalid + 1
-
-         elseif assert_failed_count == 0 then 
-            test_results.tests[i].result = "PASS"
-            test_results.tests[i].message = "All assertions have passed"
-            test_results.counts.passed = test_results.counts.passed + 1
-
-         else
-            test_results.tests[i].result = "FAIL"
-            test_results.tests[i].message = assert_failed_count .. " assertions have failed"
-            test_results.counts.failed = test_results.counts.failed + 1
-         end
-      end
-   end
-   if test_results.counts.failed == 0 and test_results.counts.invalid == 0 then
-      test_results.fully_tested = true
-   end
-   logger:info("%s: completed running tests!", filename)
-   return test_results
-end
-
 function test_runner.run_with_cleanup(file_loader: types.FileLoader, test_file: string, options: types.TestRunnerOptions): types.TestedOutput
 
    logger:info("%s: keeping track of pre-loaded packages", test_file)
@@ -131,7 +15,7 @@ function test_runner.run_with_cleanup(file_loader: types.FileLoader, test_file: 
    local test_module = file_loader.load_file(test_file) as types.Tested
    assert(type(test_module) == "table" and type(test_module.tests) == "table" and type(test_module.run_only_tests) == "boolean", "It does not appear that '" .. test_file .."' returns the 'tested' module")
 
-   local test_results = test_runner.run(test_file, test_module, options)
+   local test_results = test_module:run(test_file, options)
    
    logger:info("%s: Clearing out any packages that were loaded", test_file)
    for package_name, _ in pairs(package.loaded) do 

--- a/src/tested/types.tl
+++ b/src/tested/types.tl
@@ -124,6 +124,7 @@ local record types
       skip: function(name: string, fn: function())
       only: function(name: string, fn: function())
       conditional_test: function(name: string, condition: boolean, fn: function())
+      run: function(self: types.Tested, filename: string, options: types.TestRunnerOptions): types.TestedOutput
    end
 end
 


### PR DESCRIPTION
Moved the actual test running code into `tested.tl` instead of `test_runner` (which is now more about setting up the framework and managing the files)

If `tested.tl` gets too big, might move this someplace else and then rely on bundling to combine what is necessary.

helps with #20 