### PR TITLE
Add file output, clean up stack traces, and update docs

### DIFF
--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [linux, macos, macos-arm64]
-        lua: [lua=5.1, lua=5.2, lua=5.3, lua=5.4, luajit=@v2.0, luajit=@v2.1]
+        lua: [lua=5.1, lua=5.2, lua=5.4, luajit=@v2.1]
         include:
           - os: linux
             runner: ubuntu-latest
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        lua: [lua=5.1, lua=5.2, lua=5.3, lua=5.4, luajit=@v2.0, luajit=@v2.1]
+        lua: [lua=5.1, lua=5.2, lua=5.4, luajit=@v2.1]
         target: [mingw, vs]
     runs-on: windows-2022
     steps:

--- a/README.md
+++ b/README.md
@@ -55,5 +55,6 @@ Parts of the following are included in the source code present in this repo:
 - Bundles a slightly modified [inspect.lua](https://github.com/kikito/inspect.lua) for table diffing and viewing - MIT
 - Also bundles a slightly modified [ansicolors.lua](https://github.com/kikito/ansicolors.lua) - MIT
 - A function from [Luacov](https://github.com/lunarmodules/luacov) code to help merge stats files in process - MIT
+- Bundles [json.lua](https://github.com/rxi/json.lua)'s encoder for writing file output to json
 
 Major thanks to hishamhm, kikito, and benoit-germain for their work in the Lua space. Without them, `tested` wouldn't be possible.

--- a/build/tested.lua
+++ b/build/tested.lua
@@ -3,6 +3,8 @@ local assert_table = require("tested.assert_table")
 
 local tested = { tests = {}, run_only_tests = false }
 
+
+
 local function validate_options(test_name, options, test_src)
    local error_prefix = test_src .. " in \"" .. test_name .. "\": "
    if options.expected ~= nil then
@@ -31,6 +33,8 @@ local function extract_fn_and_options(test_name, fn_or_options, fn, test_src)
       if not fn then error("a function must be provided to run a unit test") end
       fn = fn
    end
+
+   tested.filename = test_src
 
    validate_options(test_name, options, test_src or "?")
 
@@ -160,6 +164,12 @@ local function should_skip_test(test, run_only, options)
    return nil, nil
 end
 
+local function captured_os_exit(code)
+   local prefix = "os.exit()"
+   if code then prefix = "os.exit(" .. tostring(code) .. ")" end
+   error(prefix .. " intercepted — something tried to exit out of the process", 0)
+end
+
 local function set_result(ok, err, total_assertions, assert_failed_count, test_output)
    if ok == false then
       test_output.result = "EXCEPTION"
@@ -269,8 +279,8 @@ function tested:run(filename, options)
             total_assertions = total_assertions + 1
 
             local assertion_result = {}
-            local file_info = debug.getinfo(2, "Sl")
-            assertion_result.filename = file_info.short_src
+            local file_info = debug.getinfo(2, "l")
+            assertion_result.filename = tested.filename
             assertion_result.line_number = file_info.currentline
 
             assertion_result.given = assertion.given
@@ -289,22 +299,31 @@ function tested:run(filename, options)
          end
 
 
-         local original_os_exit = os.exit
-         os.exit = function(code)
-            local prefix = "os.exit()"
-            if code then prefix = "os.exit(" .. tostring(code) .. ")" end
-            error(prefix .. " intercepted — something tried to exit out of the process", 0)
+         local start = os.clock()
+
+         local original_os_exit
+         if _VERSION == "Lua 5.1" then
+
+            original_os_exit = getfenv(test.fn).os.exit
+            getfenv(test.fn).os.exit = captured_os_exit
+         else
+            original_os_exit = os.exit
          end
 
 
-         local start = os.clock()
          local ok, err = xpcall(test.fn, xpcall_handler)
          test_results.tests[i].time = os.clock() - start
          test_results.total_time = test_results.total_time + test_results.tests[i].time
 
 
          self.assert = original_assert
-         os.exit = original_os_exit
+
+
+         if _VERSION == "Lua 5.1" then
+            getfenv(test.fn).os.exit = original_os_exit
+         else
+            os.exit = original_os_exit
+         end
 
          set_result(ok, err, total_assertions, assert_failed_count, test_results.tests[i])
 

--- a/build/tested.lua
+++ b/build/tested.lua
@@ -163,7 +163,7 @@ end
 local function set_result(ok, err, total_assertions, assert_failed_count, test_output)
    if ok == false then
       test_output.result = "EXCEPTION"
-      test_output.message = err .. "\n" .. debug.traceback()
+      test_output.message = err
 
    elseif total_assertions == 0 then
       test_output.result = "UNKNOWN"
@@ -238,6 +238,11 @@ function tested:run(filename, options)
       tested.before_fn()
    end
 
+   local function xpcall_handler(e)
+      local msg = type(e) == "string" and (e) or tostring(e)
+      return msg .. debug.traceback("", 2)
+   end
+
    for i, test in ipairs(self.tests) do
 
       test_results.tests[i] = { assertion_results = {}, name = test.name }
@@ -283,11 +288,19 @@ function tested:run(filename, options)
             return ok, err
          end
 
+         local original_os_exit = os.exit
+         os.exit = function(code)
+            local prefix = "os.exit()"
+            if code then prefix = "os.exit(" .. tostring(code) .. ")" end
+            error(prefix .. " intercepted — something tried to exit out of the process", 0)
+         end
+
          local start = os.clock()
-         local ok, err = pcall(test.fn)
+         local ok, err = xpcall(test.fn, xpcall_handler)
          test_results.tests[i].time = os.clock() - start
          test_results.total_time = test_results.total_time + test_results.tests[i].time
          self.assert = original_assert
+         os.exit = original_os_exit
 
          set_result(ok, err, total_assertions, assert_failed_count, test_results.tests[i])
 

--- a/build/tested.lua
+++ b/build/tested.lua
@@ -288,6 +288,7 @@ function tested:run(filename, options)
             return ok, err
          end
 
+
          local original_os_exit = os.exit
          os.exit = function(code)
             local prefix = "os.exit()"
@@ -295,10 +296,13 @@ function tested:run(filename, options)
             error(prefix .. " intercepted — something tried to exit out of the process", 0)
          end
 
+
          local start = os.clock()
          local ok, err = xpcall(test.fn, xpcall_handler)
          test_results.tests[i].time = os.clock() - start
          test_results.total_time = test_results.total_time + test_results.tests[i].time
+
+
          self.assert = original_assert
          os.exit = original_os_exit
 

--- a/build/tested.lua
+++ b/build/tested.lua
@@ -308,6 +308,7 @@ function tested:run(filename, options)
             getfenv(test.fn).os.exit = captured_os_exit
          else
             original_os_exit = os.exit
+            os.exit = captured_os_exit
          end
 
 

--- a/build/tested/cli.lua
+++ b/build/tested/cli.lua
@@ -81,9 +81,9 @@ function cli.parse_args(version)
    choices({ "terminal", "plain", "tap" }):
    default("terminal"),
    parser:option("-z --custom-formatter"):
-   description("File that loads a custom formatter to use for output"))
+   description("File that loads a custom formatter to use for terminal output"))
 
-   parser:option("-o --output"):
+   parser:option("-o --output-file"):
    description("Output file to save test results in (currently supported extensions: '.txt' and '.json')"):
    count("*")
    parser:option("-n --threads"):
@@ -125,8 +125,8 @@ function cli.set_defaults(args)
    for _, display_option in ipairs(args.show) do if display_option == "all" then show_all = true; break end end
    if show_all then args.show = { "skip", "pass", "fail", "exception", "unknown", "expected", "unexpected" } end
 
-   if #args.output > 0 then
-      for _, output_file in ipairs(args.output) do
+   if #args.output_file > 0 then
+      for _, output_file in ipairs(args.output_file) do
          if not (util.get_file_extension(output_file) == ".txt" or util.get_file_extension(output_file) == ".json") then
             error("The given output file does not have a supported file extension: '" .. output_file .. "'. Supported file extensions are: '.txt', '.json'", 0)
          end

--- a/build/tested/cli.lua
+++ b/build/tested/cli.lua
@@ -3,10 +3,12 @@ local lfs = require("lfs")
 
 local logging = require("tested.libs.logging")
 local logger = logging.get_logger("tested.cli")
+local util = require("tested.util")
 
 
 
 local cli = { CLIOptions = {} }
+
 
 
 
@@ -81,8 +83,11 @@ function cli.parse_args(version)
    parser:option("-z --custom-formatter"):
    description("File that loads a custom formatter to use for output"))
 
+   parser:option("-o --output"):
+   description("Output file to save test results in (currently supported extensions: '.txt' and '.json')"):
+   count("*")
    parser:option("-n --threads"):
-   description("Set the number of threads to run the tests with (default: 4). Set to 0 to disable."):
+   description("Set the number of threads to run the tests with (default: 4). Set to 0 to disable. Test files are split amongst the threads."):
    default(4):
    convert(tonumber)
    parser:option("-x --format-handler"):
@@ -119,6 +124,14 @@ function cli.set_defaults(args)
    local show_all = false
    for _, display_option in ipairs(args.show) do if display_option == "all" then show_all = true; break end end
    if show_all then args.show = { "skip", "pass", "fail", "exception", "unknown", "expected", "unexpected" } end
+
+   if #args.output > 0 then
+      for _, output_file in ipairs(args.output) do
+         if not (util.get_file_extension(output_file) == ".txt" or util.get_file_extension(output_file) == ".json") then
+            error("The given output file does not have a supported file extension: '" .. output_file .. "'. Supported file extensions are: '.txt', '.json'", 0)
+         end
+      end
+   end
 end
 
 function cli.validate_args(args)

--- a/build/tested/file_output/json.lua
+++ b/build/tested/file_output/json.lua
@@ -1,0 +1,142 @@
+
+
+
+
+
+
+local encode
+
+
+
+
+
+
+
+
+
+
+
+local escape_char_map = {
+   ["\\"] = "\\",
+   ["\""] = "\"",
+   ["\b"] = "b",
+   ["\f"] = "f",
+   ["\n"] = "n",
+   ["\r"] = "r",
+   ["\t"] = "t",
+}
+
+local escape_char_map_inv = { ["/"] = "/" }
+for k, v in pairs(escape_char_map) do
+   escape_char_map_inv[v] = k
+end
+
+
+local function escape_char(c)
+   return "\\" .. (escape_char_map[c] or string.format("u%04x", c:byte()))
+end
+
+
+local function encode_nil(_val)
+   return "null"
+end
+
+
+local function encode_table(val, stack)
+   local res = {}
+   stack = stack or {}
+
+
+   if stack[val] then error("circular reference") end
+
+   stack[val] = true
+
+   if rawget(val, 1) ~= nil or next(val) == nil then
+
+      local n = 0
+      for k in pairs(val) do
+         if type(k) ~= "number" then
+            error("invalid table: mixed or invalid key types")
+         end
+         n = n + 1
+      end
+      if n ~= #val then
+         error("invalid table: sparse array")
+      end
+
+      for _, v in ipairs(val) do
+         table.insert(res, encode(v, stack))
+      end
+      stack[val] = nil
+      return "[" .. table.concat(res, ",") .. "]"
+
+   else
+
+      for k, v in pairs(val) do
+         if type(k) ~= "string" then
+            error("invalid table: mixed or invalid key types")
+         end
+         table.insert(res, encode(k, stack) .. ":" .. encode(v, stack))
+      end
+      stack[val] = nil
+      return "{" .. table.concat(res, ",") .. "}"
+   end
+end
+
+
+local function encode_string(val)
+   return '"' .. val:gsub('[%z\1-\31\\"]', escape_char) .. '"'
+end
+
+
+local function encode_number(val)
+
+   if val ~= val or val <= -math.huge or val >= math.huge then
+      error("unexpected number value '" .. tostring(val) .. "'")
+   end
+   return string.format("%.14g", val)
+end
+
+
+local type_func_map = {
+   ["nil"] = encode_nil,
+   ["table"] = encode_table,
+   ["string"] = encode_string,
+   ["number"] = encode_number,
+   ["boolean"] = tostring,
+}
+
+
+encode = function(val, stack)
+   local t = type(val)
+   local f = type_func_map[t]
+   if f then
+      return f(val, stack)
+   end
+   error("unexpected type '" .. t .. "'")
+end
+
+
+
+
+
+
+local json = {}
+
+json.format = "json"
+
+
+function json.header(_version, _filepaths, _comments)
+   return ""
+end
+
+function json.results(_tested_result, _test_types_to_display)
+   return ""
+end
+
+function json.summary(runner_output)
+   return encode(runner_output)
+end
+
+
+return json

--- a/build/tested/file_output/txt.lua
+++ b/build/tested/file_output/txt.lua
@@ -1,0 +1,12 @@
+
+local plain = require("tested.results.plain")
+
+
+local txt = {}
+
+txt.format = "txt"
+txt.header = plain.header
+txt.results = plain.results
+txt.summary = plain.summary
+
+return txt

--- a/build/tested/main.lua
+++ b/build/tested/main.lua
@@ -52,13 +52,14 @@ local function register_format_handler(handlers)
       local ok, module_format_handler = pcall(require, handler)
       if ok then
          file_loader.register_handler(module_format_handler.extension, module_format_handler.loader)
-      else
-         local info, err = lfs.attributes(handler)
-         if err then error("Unable to load format handler, the file/module '" .. handler .. "' was not able to be loaded.") end
-         if info.mode ~= "file" then error("The custom format loader should point to a file, but currently appears to be a: " .. info.mode, 0) end
-
-         file_loader.load_and_register_handler(handler)
       end
+
+
+      local info, err = lfs.attributes(handler)
+      if err then error("Unable to load format handler, the file/module '" .. handler .. "' was not able to be loaded.") end
+      if info.mode ~= "file" then error("The custom format loader should point to a file, but currently appears to be a: " .. info.mode, 0) end
+
+      file_loader.load_and_register_handler(handler)
    end
 end
 

--- a/build/tested/main.lua
+++ b/build/tested/main.lua
@@ -1,16 +1,16 @@
 local lfs = require("lfs")
-local file_loader = require("tested.file_loader")
-
-local test_runner = require("tested.test_runner")
-local TestRunner, run_parallel_tests = test_runner[1], test_runner[2]
-
-local logging = require("tested.libs.logging")
-local logger = logging.get_logger("tested.main")
-
-local TESTED_VERSION = "tested v0.2.0"
-
 
 local cli = require("tested.cli")
+local file_loader = require("tested.file_loader")
+local logging = require("tested.libs.logging")
+local test_runner = require("tested.test_runner")
+
+local util = require("tested.util")
+
+local logger = logging.get_logger("tested.main")
+local TestRunner, run_parallel_tests = test_runner[1], test_runner[2]
+
+local TESTED_VERSION = "tested v0.2.0"
 
 local function load_result_formatter(args)
    if args.custom_formatter then
@@ -52,13 +52,13 @@ local function register_format_handler(handlers)
       local ok, module_format_handler = pcall(require, handler)
       if ok then
          file_loader.register_handler(module_format_handler.extension, module_format_handler.loader)
+      else
+         local info, err = lfs.attributes(handler)
+         if err then error("Unable to load format handler, the file/module '" .. handler .. "' was not able to be loaded.") end
+         if info.mode ~= "file" then error("The custom format loader should point to a file, but currently appears to be a: " .. info.mode, 0) end
+
+         file_loader.load_and_register_handler(handler)
       end
-
-      local info, err = lfs.attributes(handler)
-      if err then error("Unable to load format handler, the file/module '" .. handler .. "' was not able to be loaded.") end
-      if info.mode ~= "file" then error("The custom format loader should point to a file, but currently appears to be a: " .. info.mode, 0) end
-
-      file_loader.load_and_register_handler(handler)
    end
 end
 
@@ -83,14 +83,10 @@ local function find_tests(files, test_path)
    logger:info("Found %d test files to run in %s", #files, test_path)
 end
 
-local function get_file_extension(str)
-   return str:match("^.+(%..+)$")
-end
-
 local function get_all_test_files(args)
    local all_files = {}
    for _, test_file in ipairs(args.test_files) do
-      if file_loader.loader[get_file_extension(test_file)] then
+      if file_loader.loader[util.get_file_extension(test_file)] then
          table.insert(all_files, test_file)
       end
    end
@@ -110,7 +106,7 @@ local function run_tests(formatter, args, test_files)
    }
 
    local display_results = function(test_output)
-      formatter.results(test_output, cli.display_types(args.show))
+      print(formatter.results(test_output, cli.display_types(args.show)))
    end
 
    if args.threads == 0 or #test_files <= 1 then
@@ -127,6 +123,24 @@ local function run_tests(formatter, args, test_files)
    local runner_output = run_parallel_tests(test_files, args.threads, options, display_results)
 
    return runner_output
+end
+
+local function write_output_files(args, header_comments, runner_output)
+
+   for _, file_output in ipairs(args.output) do
+      local extension = util.get_file_extension(file_output)
+      local output_formatter = require("tested.file_output" .. extension)
+      local file_to_write, err = io.open(file_output, "w")
+      if not file_to_write then error("Unable to open file for writing: " .. err, 0) end
+      file_to_write:write(output_formatter.header(TESTED_VERSION, args.paths, header_comments))
+
+      for _, test_output in ipairs(runner_output.module_results) do
+         file_to_write:write(output_formatter.results(test_output, cli.display_types(args.show)))
+      end
+
+      file_to_write:write(output_formatter.summary(runner_output))
+      file_to_write:close()
+   end
 end
 
 local function main()
@@ -153,10 +167,13 @@ local function main()
    end
 
 
-   formatter.header(TESTED_VERSION, args.paths, header_comments)
+   print(formatter.header(TESTED_VERSION, args.paths, header_comments))
 
    local runner_output = run_tests(formatter, args, test_files)
-   formatter.summary(runner_output)
+   runner_output.tested_version = TESTED_VERSION
+   print(formatter.summary(runner_output))
+
+   write_output_files(args, header_comments, runner_output)
 
 
    if runner_output.all_fully_tested then

--- a/build/tested/main.lua
+++ b/build/tested/main.lua
@@ -127,7 +127,7 @@ end
 
 local function write_output_files(args, header_comments, runner_output)
 
-   for _, file_output in ipairs(args.output) do
+   for _, file_output in ipairs(args.output_file) do
       local extension = util.get_file_extension(file_output)
       local output_formatter = require("tested.file_output" .. extension)
       local file_to_write, err = io.open(file_output, "w")

--- a/build/tested/results/plain.lua
+++ b/build/tested/results/plain.lua
@@ -3,8 +3,6 @@ local terminal = require("tested.results.terminal")
 
 local plain = {}
 
-
-
 plain.format = "plain"
 
 

--- a/build/tested/results/tap.lua
+++ b/build/tested/results/tap.lua
@@ -7,7 +7,7 @@ tap.allow_filtering = false
 tap.format = "tap"
 
 function tap.header(_version_info, _filepaths, _comments)
-   print("TAP version 14")
+   return "TAP version 14"
 end
 
 function tap.results(tested_result, _test_types_to_display)
@@ -23,7 +23,7 @@ function tap.results(tested_result, _test_types_to_display)
       tadd.add(tap_result, test.name)
 
       if test.result == "SKIP" or test.result == "CONDITIONAL_SKIP" then
-         tadd.add(" # SKIP" or "", "\n")
+         tadd.add(" # SKIP", "\n")
       else
          tadd.add("\n")
 
@@ -48,11 +48,11 @@ function tap.results(tested_result, _test_types_to_display)
       end
    end
 
-   print(tadd.tostring())
+   return tadd.tostring()
 end
 
 function tap.summary(output)
-   print("1.." .. output.total_tests)
+   return "1.." .. output.total_tests
 end
 
 return tap

--- a/build/tested/results/terminal.lua
+++ b/build/tested/results/terminal.lua
@@ -42,11 +42,12 @@ terminal.allow_filtering = true
 terminal.colors = colors
 
 function terminal.header(version_info, filepaths, comments)
-   print(colors("%{bright}" .. version_info .. "  " .. table.concat(filepaths, " ")))
+   tadd.new("%{bright}", version_info, "  ", table.concat(filepaths, " "), "\n")
    for _, comment in ipairs(comments) do
-      print(comment)
+      tadd.add(comment, "\n")
    end
-   print()
+   tadd.add("\n")
+   return colors(tadd.tostring())
 end
 
 local function to_ms(time, add_color)
@@ -109,7 +110,7 @@ function terminal.results(tested_result, test_types_to_display)
          end
       end
    end
-   print(colors(tadd.tostring()))
+   return colors(tadd.tostring())
 end
 
 
@@ -155,7 +156,7 @@ function terminal.summary(output)
       tadd.add("\n%{bright}Fully Tested!%{reset}\n")
    end
 
-   print(colors(tadd.tostring()))
+   return colors(tadd.tostring())
 end
 
 return terminal

--- a/build/tested/types.lua
+++ b/build/tested/types.lua
@@ -158,4 +158,5 @@ local types = {}
 
 
 
+
 return types

--- a/build/tested/types.lua
+++ b/build/tested/types.lua
@@ -159,4 +159,5 @@ local types = {}
 
 
 
+
 return types

--- a/build/tested/util.lua
+++ b/build/tested/util.lua
@@ -1,0 +1,9 @@
+local util = {}
+
+
+
+function util.get_file_extension(str)
+   return str:match("^.+(%..+)$")
+end
+
+return util

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -48,6 +48,18 @@ Specify the number of threads `tested` should use. If set to `0`, will not use a
 ## `tested -z/--custom-formatter`
 `tested` supports loading a [custom result formatter](./custom-formatter.md) from the commandline. It tries to load what's passed in initially as a Lua module, and then as filepath, doing some basic checks to ensure the object returned appears to be a formatter. Only one custom formatter can be loaded and will be used to display results.
 
+## `tested -o/--output-file`
+Output file to save results to a specified file. It loads a formatter based on the file extension of the file that's passed in. The currently supported extensions are:
+
+- `.txt` - Outputs _exactly_ what is shown in the terminal (includes any filtering)
+- `.json` - Outputs the full [TestRunnerOutput](./custom-formatter.md#testrunneroutput). Everything - it does not filter anything. We're still pre v1, so the output here _could_ change.
+
+Multiple files can be specified and all will be written to at the end of the test run:
+
+```bash
+tested -o ./terminal_output.txt -o ./full_output.json
+```
+
 ## `tested -x/--format-handler`
 `tested` also supports loading [custom format handlers](./additional-formats.md). These are used to extend the functionality of tested and tap into other languages that can embed into Lua. Similar to custom output formatters, the format handler will first try and load from a Lua module and then from a filepath. This allows flexibility in distribution in how folks may want to support a custom format. Multiple format handlers can be loaded, and afterward can be used for custom formatters or the tests themselves.
 
@@ -57,8 +69,8 @@ Specify the number of threads `tested` should use. If set to `0`, will not use a
 Usage: tested ([-f {terminal,plain,tap}] | [-z <custom_formatter>])
        [-h] [-c] [-r] [-F <filter>]
        [-s {all,valid,invalid,skip,pass,fail,exception,unknown,expected,unexpected}]
-       [-n <threads>] [-x <format_handler>] [-d {DEBUG,INFO,WARNING}]
-       [--version] [<paths>] ...
+       [-o <output_file>] [-n <threads>] [-x <format_handler>]
+       [-d {DEBUG,INFO,WARNING}] [--version] [<paths>] ...
 
 A Lua/Teal Unit Testing Framework
 
@@ -79,14 +91,17 @@ Options:
                          What format to output the results in (default: 'terminal') (default: terminal)
                    -z <custom_formatter>,
    --custom-formatter <custom_formatter>
-                         File that loads a custom formatter to use for output
-          -n <threads>,  Set the number of threads to run the tests with (default: 4). Set to 0 to disable.
+                         File that loads a custom formatter to use for terminal output
+              -o <output_file>,
+   --output-file <output_file>
+                         Output file to save test results in (currently supported extensions: '.txt' and '.json')
+          -n <threads>,  Set the number of threads to run the tests with (default: 4). Set to 0 to disable. Test files are split amongst the threads.
    --threads <threads>
                  -x <format_handler>,
    --format-handler <format_handler>
                          File that loads custom formats that are Lua-compatible
         -d {DEBUG,INFO,WARNING},
    --debug {DEBUG,INFO,WARNING}
-                         Set the log level - mostly for debugging purposes (default: 'WARNING') (default: WARNING)
+                         Set the log level - mostly for debugging issues with tested (default: 'WARNING') (default: WARNING)
    --version             Show version information
 ```

--- a/docs/custom-formatter.md
+++ b/docs/custom-formatter.md
@@ -16,17 +16,17 @@ local custom_formatter = {
 -- Runs after performing all the setups and tests are about to run!
 -- version: "tested v0.0.0"
 -- filepaths: list of filepaths passed into tested.
-function custom_formatter.header(version: string, filepaths: {string}) end
+function custom_formatter.header(version: string, filepaths: {string}): string end
 
 -- Displays results after a test has been run
 function custom_formatter.results(
 	tested_result: types.TestedOutput,
 	test_types_to_display: {types.TestResult: boolean}
-) 
+): string
 end
 
 -- Outputs a summary at the end
-function custom_formatter.summary(output: types.TestRunnerOutput) end
+function custom_formatter.summary(output: types.TestRunnerOutput): string end
 
 return custom_formatter
 

--- a/docs/custom-formatter.md
+++ b/docs/custom-formatter.md
@@ -1,5 +1,5 @@
 # Custom Formatters
-As of now (1/2026), `tested` currently supports a "terminal" output and a "plain" output (which is just the terminal output without colors), with plans for a few more [in the future](https://github.com/FourierTransformer/tested/issues/21)! But we've tried to make it easy to create your own formatter for `tested`.
+As of now (1/2026), `tested` currently supports printing out a "terminal", "plain" (which is just the terminal output without colors), and "tap" output. We've tried to make it easy to create your own formatter for `tested`. You can only create a custom formatter for _display_ purposes. If you want to create a custom formatter for _file saving_ purposes, please [create an issue](https://github.com/FourierTransformer/tested/issues)!
 
 ## A basic formatter
 
@@ -128,7 +128,8 @@ An example of what `types.TestRunnerOutput` looks like. `types.TestedOutput` is 
     skipped = 0
   },
   total_tests = 5,
-  total_time = 2.1999999999966e-05
+  total_time = 2.1999999999966e-05,
+  tested_version = "tested v0.2.0"
 }
 ```
 
@@ -140,7 +141,7 @@ enum TestResult
   "SKIP"
   "CONDITIONAL_SKIP"
   "EXCEPTION"
-  "TIMEOUT"
+  -- "TIMEOUT" -- NYI
   "UNKNOWN"
   "EXPECTED_FAIL"
   "EXPECTED_EXCEPTION"
@@ -187,14 +188,15 @@ interface TestRunnerOutput
   total_time: number
   total_tests: integer
   all_fully_tested: boolean
+  tested_version: string
 end
 
 -- The actual formatter itself
 interface ResultFormatter
   format: string
   allow_filtering: boolean
-  header: function(version: string, filepaths: {string})
-  results: function(tested_result: types.TestedOutput, test_types_to_display: {types.TestResult: boolean})
-  summary: function(runner_output: types.TestRunnerOutput)
+  header: function(version: string, filepaths: {string}, comments: {string}): string
+  results: function(tested_result: types.TestedOutput, test_types_to_display: {types.TestResult: boolean}): string
+  summary: function(runner_output: types.TestRunnerOutput): string
 end
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -137,7 +137,8 @@ There are a couple CLI commands that are good to know when you get started:
 - `tested -F <pattern>` or `--filter <pattern>` will filter tests based on a `string.find` pattern. It can just be the test name, a couple words from the test name (in order), or a full on Lua pattern!
 - `tested -s <option>` or `--show <option>` supports displaying different status of tests. By default `tested` shows tests which require followup (so `fail`, `exception`, and `invalid`)
     - Ex: `tested -s pass -s skip` see all passed and skipped tests
-    - Ex: `tested -s valid`
+- `tested -o <output_file>` - save off the reuslts in a `.txt` or `.json`
+    - Ex: `tested -o ./results.json`
 
 To see the entire list of CLI options, check out the [CLI Reference](./cli.md)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,14 +10,14 @@ Things that I am one day planning to add (in no particular order):
     - [ ] `retries` and (maybe) `retry_timeout` for automatically retrying failing tests
     - [ ] tags for filtering
 - [x] Lifecycle management (`before`, `after`, `before_each`, `after_each`)
-- [ ] Table driven assertion (no more for loops around asserts!)
+- [ ] Spies
 - [ ] Stubbing
 - [ ] Mocking
 - [ ] A [pure Lua](./pure-lua.md) single-file (maybe two files) distribution [#20](https://github.com/FourierTransformer/tested/issues/20)
     - Should allow for embedding (on devices, maybe with Neovim and Love2d? )
-- [ ] File output (alongside terminal)
+- [x] File output (alongside terminal)
     - A cool fancy HTML output with the tests and coverage could be fun [#14](https://github.com/FourierTransformer/tested/issues/14)
-    - Likely JSON as well
+    - [x] Likely JSON as well
 - [ ] Test timeouts [#3](https://github.com/FourierTransformer/tested/issues/3)
 
 If there are any things you would really want to see added to a Unit testing framework, feel free to [open up a discussion](https://github.com/FourierTransformer/tested/discussions/new/choose). I'm currently open to new ideas!

--- a/docs/unit-testing.md
+++ b/docs/unit-testing.md
@@ -258,7 +258,7 @@ tested.test("this test is skipped", { run_when = false }, function() end)
 ```
 
 ## Data/table driven tests
-Since `tested` is designed to be inherently composable, so data driven or parametric tests just work with standard Lua conventions. Either entire `tested.test` or `tested.assert` can be wrapped, and as long as a good test name (for `tested.test`) or `given` (for `tested.assert`) are provided, the output will show exactly where things have failed.
+Since `tested` is designed to be inherently composable, so data driven or parametric tests just work with standard Lua conventions. Either entire `tested.test` or `tested.assert` can be wrapped, and as long as a good test name (for `tested.test`) or `given` (for `tested.assert`) are provided, the output will show exactly what has failed.
 
 === "Test"
 

--- a/docs/unit-testing.md
+++ b/docs/unit-testing.md
@@ -257,6 +257,136 @@ end)
 tested.test("this test is skipped", { run_when = false }, function() end)
 ```
 
+## Data/table driven tests
+Since `tested` is designed to be inherently composable, so data driven or parametric tests just work with standard Lua conventions. Either entire `tested.test` or `tested.assert` can be wrapped, and as long as a good test name (for `tested.test`) or `given` (for `tested.assert`) are provided, the output will show exactly where things have failed.
+
+=== "Test"
+
+    ```lua
+    local tested = require("tested")
+
+    -- 1000 individual tests: most pass, a few fail sporadically (multiples of 97)
+    for i = 1, 1000 do
+        tested.test("test #" .. i, function()
+            local expected = i * 2
+            -- fail at multiples of 97 by returning wrong value
+            local actual = (i % 97 == 0) and (expected + 1) or expected
+            tested.assert({
+                given = "i = " .. i,
+                should = "double i",
+                expected = expected,
+                actual = actual,
+            })
+        end)
+    end
+
+    -- single test with 1000 asserts: fails sporadically (multiples of 113)
+    tested.test("1000 asserts with sporadic failures", function()
+        for i = 1, 1000 do
+            local expected = i * i
+            -- fail at multiples of 113 by returning a wrong value
+            local actual = (i % 113 == 0) and (expected - 1) or expected
+            tested.assert({
+                given = "i = " .. i,
+                should = "square i",
+                expected = expected,
+                actual = actual,
+            })
+        end
+    end)
+
+    return tested
+
+    ```
+
+=== "Output"
+    ```
+    tested v0.2.0  tests/litmus_test.tl
+
+    - tests/litmus_test.tl (3.14ms)
+      ✗ test #97 (0.00ms)
+       ✗ tests/litmus_test.tl:9 - Given: i = 97  Should: double i
+          Actual: 195
+          Expected: 194
+
+      ✗ test #194 (0.00ms)
+       ✗ tests/litmus_test.tl:9 - Given: i = 194  Should: double i
+          Actual: 389
+          Expected: 388
+
+      ✗ test #291 (0.00ms)
+       ✗ tests/litmus_test.tl:9 - Given: i = 291  Should: double i
+          Actual: 583
+          Expected: 582
+
+      ✗ test #388 (0.00ms)
+       ✗ tests/litmus_test.tl:9 - Given: i = 388  Should: double i
+          Actual: 777
+          Expected: 776
+
+      ✗ test #485 (0.00ms)
+       ✗ tests/litmus_test.tl:9 - Given: i = 485  Should: double i
+          Actual: 971
+          Expected: 970
+
+      ✗ test #582 (0.00ms)
+       ✗ tests/litmus_test.tl:9 - Given: i = 582  Should: double i
+          Actual: 1165
+          Expected: 1164
+
+      ✗ test #679 (0.00ms)
+       ✗ tests/litmus_test.tl:9 - Given: i = 679  Should: double i
+          Actual: 1359
+          Expected: 1358
+
+      ✗ test #776 (0.00ms)
+       ✗ tests/litmus_test.tl:9 - Given: i = 776  Should: double i
+          Actual: 1553
+          Expected: 1552
+
+      ✗ test #873 (0.00ms)
+       ✗ tests/litmus_test.tl:9 - Given: i = 873  Should: double i
+          Actual: 1747
+          Expected: 1746
+
+      ✗ test #970 (0.00ms)
+       ✗ tests/litmus_test.tl:9 - Given: i = 970  Should: double i
+          Actual: 1941
+          Expected: 1940
+
+      ✗ 1000 asserts with sporadic failures (1.88ms)
+       ✗ tests/litmus_test.tl:24 - Given: i = 113  Should: square i
+          Actual: 12768
+          Expected: 12769
+       ✗ tests/litmus_test.tl:24 - Given: i = 226  Should: square i
+          Actual: 51075
+          Expected: 51076
+       ✗ tests/litmus_test.tl:24 - Given: i = 339  Should: square i
+          Actual: 114920
+          Expected: 114921
+       ✗ tests/litmus_test.tl:24 - Given: i = 452  Should: square i
+          Actual: 204303
+          Expected: 204304
+       ✗ tests/litmus_test.tl:24 - Given: i = 565  Should: square i
+          Actual: 319224
+          Expected: 319225
+       ✗ tests/litmus_test.tl:24 - Given: i = 678  Should: square i
+          Actual: 459683
+          Expected: 459684
+       ✗ tests/litmus_test.tl:24 - Given: i = 791  Should: square i
+          Actual: 625680
+          Expected: 625681
+       ✗ tests/litmus_test.tl:24 - Given: i = 904  Should: square i
+          Actual: 817215
+          Expected: 817216
+
+
+    Test Summary for 1001 tests (3.14ms):
+      Run: 990 passed, 11 failed
+    Other: 0 skipped, 0 invalid
+    ```
+
+
 ## Invalid tests
 If a test file has a test that throws an unhandled exception, `tested` finds a test without any asserts, or a test with `expected` set returns without that result, they are considered "invalid", and will display as such in the results and will be listed in the summary as "invalid".
 

--- a/src/tested.tl
+++ b/src/tested.tl
@@ -288,6 +288,7 @@ function tested:run(filename: string, options: types.TestRunnerOptions): types.T
             return ok, err
          end
 
+         -- also wrap os.exit before running
          local original_os_exit = os.exit
          os.exit = function(code: integer | boolean | nil)
             local prefix = "os.exit()"
@@ -295,10 +296,13 @@ function tested:run(filename: string, options: types.TestRunnerOptions): types.T
             error(prefix .. " intercepted — something tried to exit out of the process", 0)
          end
 
+         -- run the test
          local start = os.clock()
          local ok, err = xpcall(test.fn, xpcall_handler) as (boolean, string)
          test_results.tests[i].time = os.clock() - start
          test_results.total_time = test_results.total_time + test_results.tests[i].time
+
+         -- put things back
          self.assert = original_assert
          os.exit = original_os_exit
 

--- a/src/tested.tl
+++ b/src/tested.tl
@@ -308,6 +308,7 @@ function tested:run(filename: string, options: types.TestRunnerOptions): types.T
             getfenv(test.fn).os.exit = captured_os_exit
          else
             original_os_exit = os.exit
+            os.exit = captured_os_exit
          end
 
 

--- a/src/tested.tl
+++ b/src/tested.tl
@@ -163,7 +163,7 @@ end
 local function set_result(ok: boolean, err: string, total_assertions: integer, assert_failed_count: integer, test_output: types.TestOutput)
    if ok == false then
       test_output.result = "EXCEPTION"
-      test_output.message = err .. "\n" .. debug.traceback()
+      test_output.message = err
 
    elseif total_assertions == 0 then
       test_output.result = "UNKNOWN"
@@ -238,6 +238,11 @@ function tested:run(filename: string, options: types.TestRunnerOptions): types.T
       tested.before_fn()
    end
 
+   local function xpcall_handler(e: any): string
+      local msg = type(e) == "string" and (e as string) or tostring(e)
+      return msg .. debug.traceback("", 2)
+   end
+
    for i, test in ipairs(self.tests) do
 
       test_results.tests[i] = {assertion_results = {}, name = test.name}
@@ -283,11 +288,19 @@ function tested:run(filename: string, options: types.TestRunnerOptions): types.T
             return ok, err
          end
 
+         local original_os_exit = os.exit
+         os.exit = function(code: integer | boolean | nil)
+            local prefix = "os.exit()"
+            if code then prefix = "os.exit(" .. tostring(code) .. ")" end
+            error(prefix .. " intercepted — something tried to exit out of the process", 0)
+         end
+
          local start = os.clock()
-         local ok, err = pcall(test.fn) as (boolean, string)
+         local ok, err = xpcall(test.fn, xpcall_handler) as (boolean, string)
          test_results.tests[i].time = os.clock() - start
          test_results.total_time = test_results.total_time + test_results.tests[i].time
          self.assert = original_assert
+         os.exit = original_os_exit
 
          set_result(ok, err, total_assertions, assert_failed_count, test_results.tests[i])
 

--- a/src/tested.tl
+++ b/src/tested.tl
@@ -3,6 +3,8 @@ local assert_table = require("tested.assert_table")
 
 local tested: types.Tested = { tests = {}, run_only_tests = false }
 
+
+
 local function validate_options(test_name: string, options: types.TestedOptions, test_src: string)
    local error_prefix = test_src .. " in \"" .. test_name .. "\": "
    if options.expected ~= nil then
@@ -31,6 +33,8 @@ local function extract_fn_and_options(test_name: string, fn_or_options: function
       if not fn then error("a function must be provided to run a unit test") end
       fn = fn
    end
+
+   tested.filename = test_src
 
    validate_options(test_name, options, test_src or "?")
 
@@ -160,6 +164,12 @@ local function should_skip_test(test: types.Test, run_only: boolean, options: ty
    return nil, nil  -- not a skip
 end
 
+local function captured_os_exit(code: integer | boolean | nil)
+   local prefix = "os.exit()"
+   if code then prefix = "os.exit(" .. tostring(code) .. ")" end
+   error(prefix .. " intercepted — something tried to exit out of the process", 0)
+end
+
 local function set_result(ok: boolean, err: string, total_assertions: integer, assert_failed_count: integer, test_output: types.TestOutput)
    if ok == false then
       test_output.result = "EXCEPTION"
@@ -269,8 +279,8 @@ function tested:run(filename: string, options: types.TestRunnerOptions): types.T
             total_assertions = total_assertions + 1
 
             local assertion_result: types.AssertionResult = {}
-            local file_info = debug.getinfo(2, "Sl")
-            assertion_result.filename = file_info.short_src
+            local file_info = debug.getinfo(2, "l")
+            assertion_result.filename = tested.filename
             assertion_result.line_number = file_info.currentline
 
             assertion_result.given = assertion.given
@@ -288,23 +298,32 @@ function tested:run(filename: string, options: types.TestRunnerOptions): types.T
             return ok, err
          end
 
-         -- also wrap os.exit before running
-         local original_os_exit = os.exit
-         os.exit = function(code: integer | boolean | nil)
-            local prefix = "os.exit()"
-            if code then prefix = "os.exit(" .. tostring(code) .. ")" end
-            error(prefix .. " intercepted — something tried to exit out of the process", 0)
-         end
-
          -- run the test
          local start = os.clock()
+
+         local original_os_exit: function(code: integer | boolean | nil)
+         if _VERSION == "Lua 5.1" then
+            global getfenv: function(any): {string:{string:function}}
+            original_os_exit = getfenv(test.fn).os.exit
+            getfenv(test.fn).os.exit = captured_os_exit
+         else
+            original_os_exit = os.exit
+         end
+
+
          local ok, err = xpcall(test.fn, xpcall_handler) as (boolean, string)
          test_results.tests[i].time = os.clock() - start
          test_results.total_time = test_results.total_time + test_results.tests[i].time
 
          -- put things back
          self.assert = original_assert
-         os.exit = original_os_exit
+
+         -- again luajit or lua 5.1
+         if _VERSION == "Lua 5.1" then
+            getfenv(test.fn).os.exit = original_os_exit
+         else
+            os.exit = original_os_exit
+         end
 
          set_result(ok, err, total_assertions, assert_failed_count, test_results.tests[i])
 

--- a/src/tested/cli.tl
+++ b/src/tested/cli.tl
@@ -3,6 +3,7 @@ local lfs = require("lfs")
 
 local logging = require("tested.libs.logging")
 local logger = logging.get_logger("tested.cli")
+local util = require("tested.util")
 
 local type types = require("tested.types")
 
@@ -30,6 +31,7 @@ local record cli
       random: boolean
       show: {DisplayOptions}
       display_format: DisplayFormat
+      output: {string}
       custom_formatter: string
       format_handler: {string}
       paths: {string}
@@ -81,8 +83,11 @@ function cli.parse_args(version: string): cli.CLIOptions
       parser:option("-z --custom-formatter")
          :description("File that loads a custom formatter to use for output")
    )
+   parser:option("-o --output")
+      :description("Output file to save test results in (currently supported extensions: '.txt' and '.json')")
+      :count("*")
    parser:option("-n --threads")
-      :description("Set the number of threads to run the tests with (default: 4). Set to 0 to disable.")
+      :description("Set the number of threads to run the tests with (default: 4). Set to 0 to disable. Test files are split amongst the threads.")
       :default(4)
       :convert(tonumber)
    parser:option("-x --format-handler")
@@ -119,6 +124,14 @@ function cli.set_defaults(args: cli.CLIOptions)
    local show_all = false
    for _, display_option in ipairs(args.show) do if display_option == "all" then show_all = true break end end
    if show_all then args.show = {"skip", "pass", "fail", "exception", "unknown", "expected", "unexpected"} end -- NYI: timeout
+
+   if #args.output > 0 then
+      for _, output_file in ipairs(args.output) do
+         if not (util.get_file_extension(output_file) == ".txt" or util.get_file_extension(output_file) == ".json") then
+            error("The given output file does not have a supported file extension: '" .. output_file .. "'. Supported file extensions are: '.txt', '.json'", 0)
+         end
+      end
+   end
 end
 
 function cli.validate_args(args: cli.CLIOptions)

--- a/src/tested/cli.tl
+++ b/src/tested/cli.tl
@@ -31,7 +31,7 @@ local record cli
       random: boolean
       show: {DisplayOptions}
       display_format: DisplayFormat
-      output: {string}
+      output_file: {string}
       custom_formatter: string
       format_handler: {string}
       paths: {string}
@@ -81,9 +81,9 @@ function cli.parse_args(version: string): cli.CLIOptions
          :choices({"terminal", "plain", "tap"})
          :default("terminal"),
       parser:option("-z --custom-formatter")
-         :description("File that loads a custom formatter to use for output")
+         :description("File that loads a custom formatter to use for terminal output")
    )
-   parser:option("-o --output")
+   parser:option("-o --output-file")
       :description("Output file to save test results in (currently supported extensions: '.txt' and '.json')")
       :count("*")
    parser:option("-n --threads")
@@ -125,8 +125,8 @@ function cli.set_defaults(args: cli.CLIOptions)
    for _, display_option in ipairs(args.show) do if display_option == "all" then show_all = true break end end
    if show_all then args.show = {"skip", "pass", "fail", "exception", "unknown", "expected", "unexpected"} end -- NYI: timeout
 
-   if #args.output > 0 then
-      for _, output_file in ipairs(args.output) do
+   if #args.output_file > 0 then
+      for _, output_file in ipairs(args.output_file) do
          if not (util.get_file_extension(output_file) == ".txt" or util.get_file_extension(output_file) == ".json") then
             error("The given output file does not have a supported file extension: '" .. output_file .. "'. Supported file extensions are: '.txt', '.json'", 0)
          end

--- a/src/tested/file_output/json.tl
+++ b/src/tested/file_output/json.tl
@@ -1,0 +1,142 @@
+local type types = require("tested.types")
+
+-------------------------------------------------------------------------------
+-- JSON Encoder from rxi/json.lua - used under MIT License
+-------------------------------------------------------------------------------
+
+local encode: function(val: table, stack?: table): string
+
+local enum ESCAPE_CHAR
+  "\\"
+  "\""
+  "\b"
+  "\f"
+  "\n"
+  "\r"
+  "\t"
+end
+
+local escape_char_map: {ESCAPE_CHAR:string} = {
+  [ "\\" ] = "\\",
+  [ "\"" ] = "\"",
+  [ "\b" ] = "b",
+  [ "\f" ] = "f",
+  [ "\n" ] = "n",
+  [ "\r" ] = "r",
+  [ "\t" ] = "t",
+}
+
+local escape_char_map_inv: {string:string} = { [ "/" ] = "/" }
+for k, v in pairs(escape_char_map) do
+  escape_char_map_inv[v] = k
+end
+
+
+local function escape_char(c: ESCAPE_CHAR): string
+  return "\\" .. (escape_char_map[c] or string.format("u%04x", c:byte()))
+end
+
+
+local function encode_nil(_val: nil): string
+  return "null"
+end
+
+
+local function encode_table(val: table, stack: table): string
+  local res = {}
+  stack = stack or {}
+
+  -- Circular reference?
+  if stack[val] then error("circular reference") end
+
+  stack[val] = true
+
+  if rawget(val, 1) ~= nil or next(val) == nil then
+    -- Treat as array -- check keys are valid and it is not sparse
+    local n = 0
+    for k in pairs(val) do
+      if type(k) ~= "number" then
+        error("invalid table: mixed or invalid key types")
+      end
+      n = n + 1
+    end
+    if n ~= #val as {any} then
+      error("invalid table: sparse array")
+    end
+    -- Encode
+    for _, v in ipairs(val as {table}) do
+      table.insert(res, encode(v, stack))
+    end
+    stack[val] = nil
+    return "[" .. table.concat(res, ",") .. "]"
+
+  else
+    -- Treat as an object
+    for k, v in pairs(val as {table:table}) do
+      if type(k) ~= "string" then
+        error("invalid table: mixed or invalid key types")
+      end
+      table.insert(res, encode(k, stack) .. ":" .. encode(v, stack))
+    end
+    stack[val] = nil
+    return "{" .. table.concat(res, ",") .. "}"
+  end
+end
+
+
+local function encode_string(val: string): string
+  return '"' .. val:gsub('[%z\1-\31\\"]', escape_char) .. '"'
+end
+
+
+local function encode_number(val: number): string
+  -- Check for NaN, -inf and inf
+  if val ~= val or val <= -math.huge or val >= math.huge then
+    error("unexpected number value '" .. tostring(val) .. "'")
+  end
+  return string.format("%.14g", val)
+end
+
+
+local type_func_map: {string:any} = {
+  [ "nil"     ] = encode_nil,
+  [ "table"   ] = encode_table,
+  [ "string"  ] = encode_string,
+  [ "number"  ] = encode_number,
+  [ "boolean" ] = tostring,
+}
+
+
+encode = function(val: table, stack?: table): string
+  local t = type(val)
+  local f = type_func_map[t] as function(table, table)
+  if f then
+    return f(val, stack) as string
+  end
+  error("unexpected type '" .. t .. "'")
+end
+
+
+-------------------------------------------------------------------------------
+-- Below is standard `tested` licensed code
+-------------------------------------------------------------------------------
+
+local record json is types.ResultFormatter where self.format == "json" end
+
+json.format = "json"
+
+
+function json.header(_version: string, _filepaths: {string}, _comments: {string}): string
+    return ""
+end
+
+function json.results(_tested_result: types.TestedOutput, _test_types_to_display: {types.TestResult: boolean}): string
+    return ""
+end
+
+function json.summary(runner_output: types.TestRunnerOutput): string
+    return encode(runner_output as table)
+end
+
+
+return json

--- a/src/tested/file_output/txt.tl
+++ b/src/tested/file_output/txt.tl
@@ -1,0 +1,12 @@
+-- this is just the plain results formatter
+local plain = require("tested.results.plain")
+local type types = require("tested.types")
+
+local record txt is types.ResultFormatter where self.format == "txt" end
+
+txt.format = "txt"
+txt.header = plain.header
+txt.results = plain.results
+txt.summary = plain.summary
+
+return txt

--- a/src/tested/main.tl
+++ b/src/tested/main.tl
@@ -127,7 +127,7 @@ end
 
 local function write_output_files(args: cli.CLIOptions, header_comments: {string}, runner_output: types.TestRunnerOutput)
    -- write out all the files at the end
-   for _, file_output in ipairs(args.output) do
+   for _, file_output in ipairs(args.output_file) do
       local extension = util.get_file_extension(file_output)
       local output_formatter = require("tested.file_output" .. extension) as types.ResultFormatter
       local file_to_write, err = io.open(file_output, "w")

--- a/src/tested/main.tl
+++ b/src/tested/main.tl
@@ -52,13 +52,14 @@ local function register_format_handler(handlers: {string})
       local ok, module_format_handler = pcall(require, handler) as (boolean, types.FileLoaderHandler)
       if ok then
           file_loader.register_handler(module_format_handler.extension, module_format_handler.loader)
-      else
-         local info, err = lfs.attributes(handler)
-         if err then error("Unable to load format handler, the file/module '" .. handler .."' was not able to be loaded.") end
-         if info.mode ~= "file" then error("The custom format loader should point to a file, but currently appears to be a: " .. info.mode, 0) end
-
-         file_loader.load_and_register_handler(handler)
       end
+
+      -- let people override an installed handler if desired
+      local info, err = lfs.attributes(handler)
+      if err then error("Unable to load format handler, the file/module '" .. handler .."' was not able to be loaded.") end
+      if info.mode ~= "file" then error("The custom format loader should point to a file, but currently appears to be a: " .. info.mode, 0) end
+
+      file_loader.load_and_register_handler(handler)
    end
 end
 

--- a/src/tested/main.tl
+++ b/src/tested/main.tl
@@ -1,16 +1,16 @@
 local lfs = require("lfs")
-local file_loader = require("tested.file_loader")
 
+local cli = require("tested.cli")
+local file_loader = require("tested.file_loader")
+local logging = require("tested.libs.logging")
 local test_runner = require("tested.test_runner")
+local type types = require("tested.types")
+local util = require("tested.util")
+
+local logger = logging.get_logger("tested.main")
 local TestRunner, run_parallel_tests = test_runner[1], test_runner[2]
 
-local logging = require("tested.libs.logging")
-local logger = logging.get_logger("tested.main")
-
 local TESTED_VERSION = "tested v0.2.0"
-
-local type types = require("tested.types")
-local cli = require("tested.cli")
 
 local function load_result_formatter(args: cli.CLIOptions): types.ResultFormatter
    if args.custom_formatter then
@@ -52,13 +52,13 @@ local function register_format_handler(handlers: {string})
       local ok, module_format_handler = pcall(require, handler) as (boolean, types.FileLoaderHandler)
       if ok then
           file_loader.register_handler(module_format_handler.extension, module_format_handler.loader)
+      else
+         local info, err = lfs.attributes(handler)
+         if err then error("Unable to load format handler, the file/module '" .. handler .."' was not able to be loaded.") end
+         if info.mode ~= "file" then error("The custom format loader should point to a file, but currently appears to be a: " .. info.mode, 0) end
+
+         file_loader.load_and_register_handler(handler)
       end
-
-      local info, err = lfs.attributes(handler)
-      if err then error("Unable to load format handler, the file/module '" .. handler .."' was not able to be loaded.") end
-      if info.mode ~= "file" then error("The custom format loader should point to a file, but currently appears to be a: " .. info.mode, 0) end
-
-      file_loader.load_and_register_handler(handler)
    end
 end
 
@@ -83,14 +83,10 @@ local function find_tests(files: {string}, test_path: string): {string}
    logger:info("Found %d test files to run in %s", #files, test_path)
 end
 
-local function get_file_extension(str: string): string
-   return str:match("^.+(%..+)$")
-end
-
 local function get_all_test_files(args: cli.CLIOptions): {string}
    local all_files = {}
    for _, test_file in ipairs(args.test_files) do
-      if file_loader.loader[get_file_extension(test_file)] then
+      if file_loader.loader[util.get_file_extension(test_file)] then
          table.insert(all_files, test_file)
       end
    end
@@ -110,7 +106,7 @@ local function run_tests(formatter: types.ResultFormatter, args: cli.CLIOptions,
    }
 
    local display_results = function(test_output: types.TestedOutput)
-      formatter.results(test_output, cli.display_types(args.show))
+      print(formatter.results(test_output, cli.display_types(args.show)))
    end
 
    if args.threads == 0 or #test_files <= 1 then
@@ -127,6 +123,24 @@ local function run_tests(formatter: types.ResultFormatter, args: cli.CLIOptions,
    local runner_output = run_parallel_tests(test_files, args.threads, options, display_results)
 
    return runner_output
+end
+
+local function write_output_files(args: cli.CLIOptions, header_comments: {string}, runner_output: types.TestRunnerOutput)
+   -- write out all the files at the end
+   for _, file_output in ipairs(args.output) do
+      local extension = util.get_file_extension(file_output)
+      local output_formatter = require("tested.file_output" .. extension) as types.ResultFormatter
+      local file_to_write, err = io.open(file_output, "w")
+      if not file_to_write then error("Unable to open file for writing: " .. err, 0) end
+      file_to_write:write(output_formatter.header(TESTED_VERSION, args.paths, header_comments))
+
+      for _, test_output in ipairs(runner_output.module_results) do
+         file_to_write:write(output_formatter.results(test_output, cli.display_types(args.show)))
+      end
+
+      file_to_write:write(output_formatter.summary(runner_output))
+      file_to_write:close()
+   end
 end
 
 local function main()
@@ -153,10 +167,13 @@ local function main()
    end
 
    -- running the tests
-   formatter.header(TESTED_VERSION, args.paths, header_comments)
+   print(formatter.header(TESTED_VERSION, args.paths, header_comments))
 
    local runner_output = run_tests(formatter, args, test_files)
-   formatter.summary(runner_output)
+   runner_output.tested_version = TESTED_VERSION
+   print(formatter.summary(runner_output))
+
+   write_output_files(args, header_comments, runner_output)
 
    -- exiting cleanly
    if runner_output.all_fully_tested then

--- a/src/tested/results/plain.tl
+++ b/src/tested/results/plain.tl
@@ -1,9 +1,7 @@
 local terminal = require("tested.results.terminal")
 local type types = require("tested.types")
 
-local record plain is types.ResultFormatter where self.format == "plain"
-
-end
+local record plain is types.ResultFormatter where self.format == "plain" end
 
 plain.format = "plain"
 

--- a/src/tested/results/tap.tl
+++ b/src/tested/results/tap.tl
@@ -6,11 +6,11 @@ local record tap is types.ResultFormatter where self.format == "tap" end
 tap.allow_filtering = false
 tap.format = "tap"
 
-function tap.header(_version_info: string, _filepaths: {string}, _comments: {string})
-   print("TAP version 14")
+function tap.header(_version_info: string, _filepaths: {string}, _comments: {string}): string
+   return "TAP version 14"
 end
 
-function tap.results(tested_result: types.TestedOutput, _test_types_to_display: {types.TestResult: boolean})
+function tap.results(tested_result: types.TestedOutput, _test_types_to_display: {types.TestResult: boolean}): string
    tadd.new("# ", tested_result.filename, "\n")
    local tap_result: string
    
@@ -23,7 +23,7 @@ function tap.results(tested_result: types.TestedOutput, _test_types_to_display: 
       tadd.add(tap_result, test.name)
       
       if test.result == "SKIP" or test.result == "CONDITIONAL_SKIP" then
-         tadd.add(" # SKIP" or "", "\n")
+         tadd.add(" # SKIP", "\n")
       else
          tadd.add("\n")
       
@@ -48,11 +48,11 @@ function tap.results(tested_result: types.TestedOutput, _test_types_to_display: 
       end
    end
 
-   print(tadd.tostring())
+   return tadd.tostring()
 end
 
-function tap.summary(output: types.TestRunnerOutput)
-   print("1.." .. output.total_tests)
+function tap.summary(output: types.TestRunnerOutput): string
+   return "1.." .. output.total_tests
 end
 
 return tap

--- a/src/tested/results/terminal.tl
+++ b/src/tested/results/terminal.tl
@@ -41,12 +41,13 @@ terminal.allow_filtering = true
 -- used to disable the colors in the "plain" formatter
 terminal.colors = colors
 
-function terminal.header(version_info: string, filepaths: {string}, comments: {string})
-   print(colors("%{bright}" .. version_info .. "  " .. table.concat(filepaths, " ")))
+function terminal.header(version_info: string, filepaths: {string}, comments: {string}): string
+   tadd.new("%{bright}", version_info, "  ", table.concat(filepaths, " "), "\n")
    for _, comment in ipairs(comments) do
-      print(comment)
+      tadd.add(comment, "\n")
    end
-   print()
+   tadd.add("\n")
+   return colors(tadd.tostring())
 end
 
 local function to_ms(time: number, add_color?: boolean): string
@@ -81,7 +82,7 @@ local function format_assertion_result(assertion_result: types.AssertionResult):
    tadd.add("\n")
 end
 
-function terminal.results(tested_result: types.TestedOutput, test_types_to_display: {types.TestResult: boolean})
+function terminal.results(tested_result: types.TestedOutput, test_types_to_display: {types.TestResult: boolean}): string
    tadd.new("%{bright}- ", tested_result.filename, to_ms(tested_result.total_time), "%{reset}\n")
    for _, test_result in ipairs(tested_result.tests) do
 
@@ -103,13 +104,13 @@ function terminal.results(tested_result: types.TestedOutput, test_types_to_displ
             if extra_newline then tadd.add("\n") end
          end
 
-         if test_result.result == "EXCEPTION" or test_result.result == "UNKNOWN" or test_result.result == "UNEXPECTED" or test_result.result == "EXPECTED_EXCEPTION" or test_result.result == "EXPECTED_UNKNOWN"then
+         if test_result.result == "EXCEPTION" or test_result.result == "UNKNOWN" or test_result.result == "UNEXPECTED" or test_result.result == "EXPECTED_EXCEPTION" or test_result.result == "EXPECTED_UNKNOWN" then
             tadd.add("      ", (test_result.message:gsub("\n", "\n      ")), "\n")
             tadd.add("\n")
          end
       end
    end
-   print(colors(tadd.tostring()))
+   return colors(tadd.tostring())
 end
 
 -- just being particular!
@@ -121,7 +122,7 @@ local function test_counts_s(test_count: integer): string
    end
 end
 
-function terminal.summary(output: types.TestRunnerOutput)
+function terminal.summary(output: types.TestRunnerOutput): string
    tadd.new("%{bright}Test Summary for ", test_counts_s(output.total_tests), to_ms(output.total_time, false), ":%{reset}\n")
    
    tadd.add(
@@ -155,7 +156,7 @@ function terminal.summary(output: types.TestRunnerOutput)
       tadd.add("\n%{bright}Fully Tested!%{reset}\n")
    end
 
-   print(colors(tadd.tostring()))
+   return colors(tadd.tostring())
 end
 
 return terminal

--- a/src/tested/types.tl
+++ b/src/tested/types.tl
@@ -137,6 +137,7 @@ local record types
    interface Tested
       tests: {Test}
       run_only_tests: boolean
+      filename: string
 
       before_fn: function()
       after_fn: function()

--- a/src/tested/types.tl
+++ b/src/tested/types.tl
@@ -75,15 +75,16 @@ local record types
       total_time: number
       total_tests: integer
       all_fully_tested: boolean
+      tested_version: string
    end
 
    -- needed for result handling
    interface ResultFormatter
       format: string
       allow_filtering: boolean
-      header: function(version: string, filepaths: {string}, comments: {string})
-      results: function(tested_result: types.TestedOutput, test_types_to_display: {types.TestResult: boolean})
-      summary: function(runner_output: types.TestRunnerOutput)
+      header: function(version: string, filepaths: {string}, comments: {string}): string
+      results: function(tested_result: types.TestedOutput, test_types_to_display: {types.TestResult: boolean}): string
+      summary: function(runner_output: types.TestRunnerOutput): string
    end
 
    -- needed for registering new file types

--- a/src/tested/util.tl
+++ b/src/tested/util.tl
@@ -1,0 +1,9 @@
+local record util end
+
+-- i generally don't like utils, but so it goes! if we get enough and they're groupable enough i'll
+-- create a utils/str.tl or something
+function util.get_file_extension(str: string): string
+   return str:match("^.+(%..+)$")
+end
+
+return util

--- a/tested-dev-1.rockspec
+++ b/tested-dev-1.rockspec
@@ -37,12 +37,16 @@ build = {
       ["tested.main"] = "build/tested/main.lua",
       ["tested.test_runner"] = "build/tested/test_runner.lua",
       ["tested.types"] = "build/tested/types.lua",
+      ["tested.util"] = "build/tested/util.lua",
 
       ["tested.libs.ansicolors"] = "build/tested/libs/ansicolors.lua",
       ["tested.libs.inspect"] = "build/tested/libs/inspect.lua",
       ["tested.libs.logging"] = "build/tested/libs/logging.lua",
       ["tested.libs.tadd"] = "build/tested/libs/tadd.lua",
       ["tested.libs.ThreadPool"] = "build/tested/libs/ThreadPool.lua",
+
+      ["tested.file_output.txt"] = "build/tested/file_output/txt.lua",
+      ["tested.file_output.json"] = "build/tested/file_output/json.lua",
 
       ["tested.results.plain"] = "build/tested/results/plain.lua",
       ["tested.results.tap"] = "build/tested/results/tap.lua",
@@ -67,6 +71,9 @@ build = {
          ["tested.libs.logging"] = "src/tested/libs/logging.tl",
          ["tested.libs.tadd"] = "src/tested/libs/tadd.tl",
          ["tested.libs.ThreadPool"] = "src/tested/libs/ThreadPool.tl",
+
+         ["tested.file_output.txt"] = "src/tested/file_output/txt.tl",
+         ["tested.file_output.json"] = "src/tested/file_output/json.tl",
 
          ["tested.results.plain"] = "src/tested/results/plain.tl",
          ["tested.results.tap"] = "src/tested/results/tap.tl",

--- a/tests/custom_formatter_test.lua
+++ b/tests/custom_formatter_test.lua
@@ -11,166 +11,32 @@ local function run(test_file)
     return out
 end
 
--- header()
-
-tested.test("header line appears in output", function()
+tested.test("custom formatter output for fully_working_test.lua", function()
     local out = run("tests/fully_working_test.lua")
-    tested.assert({
-        given = "custom formatter output",
-        should = "contain CFMT_HEADER line",
-        expected = true,
-        actual = out:find("CFMT_HEADER") ~= nil
-    })
+    tested.assert({ given = "custom formatter output", should = "contain CFMT_HEADER line", expected = true, actual = out:find("CFMT_HEADER") ~= nil })
+    tested.assert({ given = "CFMT_HEADER line", should = "contain the test file path", expected = true, actual = out:find("fully_working_test%.lua") ~= nil })
+    tested.assert({ given = "CFMT_HEADER line", should = "contain 'tested v'", expected = true, actual = out:find("tested v") ~= nil })
+    tested.assert({ given = "results output", should = "contain CFMT_FILE with filename", expected = true, actual = out:find("CFMT_FILE tests/fully_working_test%.lua") ~= nil })
+    tested.assert({ given = "first test in fully_working_test.lua", should = "appear as CFMT_TEST PASS", expected = true, actual = out:find("CFMT_TEST PASS just works!") ~= nil })
+    tested.assert({ given = "second test in fully_working_test.lua", should = "appear as CFMT_TEST PASS", expected = true, actual = out:find("CFMT_TEST PASS just works without given and should!") ~= nil })
+    tested.assert({ given = "custom formatter output", should = "contain CFMT_SUMMARY line", expected = true, actual = out:find("CFMT_SUMMARY") ~= nil })
+    tested.assert({ given = "CFMT_SUMMARY for fully_working_test.lua", should = "show total=2", expected = true, actual = out:find("total=2") ~= nil })
+    tested.assert({ given = "CFMT_SUMMARY for fully_working_test.lua", should = "show passed=2", expected = true, actual = out:find("passed=2") ~= nil })
+    tested.assert({ given = "CFMT_SUMMARY for fully_working_test.lua", should = "show failed=0", expected = true, actual = out:find("failed=0") ~= nil })
 end)
 
-tested.test("header contains the test filename", function()
-    local out = run("tests/fully_working_test.lua")
-    tested.assert({
-        given = "CFMT_HEADER line",
-        should = "contain the test file path",
-        expected = true,
-        actual = out:find("fully_working_test%.lua") ~= nil
-    })
-end)
-
-tested.test("header contains the tested version", function()
-    local out = run("tests/fully_working_test.lua")
-    tested.assert({
-        given = "CFMT_HEADER line",
-        should = "contain 'tested v'",
-        expected = true,
-        actual = out:find("tested v") ~= nil
-    })
-end)
-
--- results() — file section and PASS
-
-tested.test("file section line appears with correct filename", function()
-    local out = run("tests/fully_working_test.lua")
-    tested.assert({
-        given = "results output",
-        should = "contain CFMT_FILE with filename",
-        expected = true,
-        actual = out:find("CFMT_FILE tests/fully_working_test%.lua") ~= nil
-    })
-end)
-
-tested.test("each passing test gets a CFMT_TEST PASS line", function()
-    local out = run("tests/fully_working_test.lua")
-    tested.assert({
-        given = "first test in fully_working_test.lua",
-        should = "appear as CFMT_TEST PASS",
-        expected = true,
-        actual = out:find("CFMT_TEST PASS just works!") ~= nil
-    })
-    tested.assert({
-        given = "second test in fully_working_test.lua",
-        should = "appear as CFMT_TEST PASS",
-        expected = true,
-        actual = out:find("CFMT_TEST PASS just works without given and should!") ~= nil
-    })
-end)
-
--- results() — skip variants
-
-tested.test("run_when=false test appears as CFMT_TEST CONDITIONAL_SKIP", function()
-    -- tested_test.tl contains: tested.test("conditional guy should be skipped", {run_when=false}, ...)
+tested.test("custom formatter output for tested_test.tl", function()
     local out = run("tests/tested_test.tl")
-    tested.assert({
-        given = "test with run_when=false",
-        should = "appear as CFMT_TEST CONDITIONAL_SKIP",
-        expected = true,
-        actual = out:find("CFMT_TEST CONDITIONAL_SKIP conditional guy should be skipped") ~= nil
-    })
+    tested.assert({ given = "test with run_when=false", should = "appear as CFMT_TEST CONDITIONAL_SKIP", expected = true, actual = out:find("CFMT_TEST CONDITIONAL_SKIP conditional guy should be skipped") ~= nil })
+    tested.assert({ given = "CFMT_SUMMARY for tested_test.tl", should = "show failed > 0", expected = false, actual = out:find("failed=0") ~= nil })
+    tested.assert({ given = "CFMT_SUMMARY for tested_test.tl", should = "show skipped=1", expected = true, actual = out:find("skipped=1") ~= nil })
 end)
 
--- results() — expected result types
-
-tested.test("expected-fail test appears as CFMT_TEST EXPECTED_FAIL", function()
+tested.test("custom formatter output for expected_test.tl", function()
     local out = run("tests/expected_test.tl")
-    tested.assert({
-        given = "test with {expected='FAIL'} that fails",
-        should = "appear as CFMT_TEST EXPECTED_FAIL",
-        expected = true,
-        actual = out:find("CFMT_TEST EXPECTED_FAIL") ~= nil
-    })
-end)
-
-tested.test("expected-exception test appears as CFMT_TEST EXPECTED_EXCEPTION", function()
-    local out = run("tests/expected_test.tl")
-    tested.assert({
-        given = "test with {expected='EXCEPTION'} that throws",
-        should = "appear as CFMT_TEST EXPECTED_EXCEPTION",
-        expected = true,
-        actual = out:find("CFMT_TEST EXPECTED_EXCEPTION") ~= nil
-    })
-end)
-
-tested.test("test that doesn't match its expected result appears as CFMT_TEST UNEXPECTED", function()
-    local out = run("tests/expected_test.tl")
-    tested.assert({
-        given = "test with {expected='FAIL'} that passes",
-        should = "appear as CFMT_TEST UNEXPECTED",
-        expected = true,
-        actual = out:find("CFMT_TEST UNEXPECTED") ~= nil
-    })
-end)
-
--- summary()
-
-tested.test("summary line appears in output", function()
-    local out = run("tests/fully_working_test.lua")
-    tested.assert({
-        given = "custom formatter output",
-        should = "contain CFMT_SUMMARY line",
-        expected = true,
-        actual = out:find("CFMT_SUMMARY") ~= nil
-    })
-end)
-
-tested.test("summary shows correct total and passed counts for all-passing run", function()
-    local out = run("tests/fully_working_test.lua")
-    -- fully_working_test.lua has exactly 2 passing tests
-    tested.assert({
-        given = "CFMT_SUMMARY for fully_working_test.lua",
-        should = "show total=2",
-        expected = true,
-        actual = out:find("total=2") ~= nil
-    })
-    tested.assert({
-        given = "CFMT_SUMMARY for fully_working_test.lua",
-        should = "show passed=2",
-        expected = true,
-        actual = out:find("passed=2") ~= nil
-    })
-    tested.assert({
-        given = "CFMT_SUMMARY for fully_working_test.lua",
-        should = "show failed=0",
-        expected = true,
-        actual = out:find("failed=0") ~= nil
-    })
-end)
-
-tested.test("summary shows non-zero failed count when tests fail", function()
-    -- tested_test.tl has known failing tests (sum() fails several assertions)
-    local out = run("tests/tested_test.tl")
-    tested.assert({
-        given = "CFMT_SUMMARY for tested_test.tl",
-        should = "show failed > 0",
-        expected = false,
-        actual = out:find("failed=0") ~= nil
-    })
-end)
-
-tested.test("summary skipped count reflects conditional skips", function()
-    -- tested_test.tl has one run_when=false test → skipped=1
-    local out = run("tests/tested_test.tl")
-    tested.assert({
-        given = "CFMT_SUMMARY for tested_test.tl",
-        should = "show skipped=1",
-        expected = true,
-        actual = out:find("skipped=1") ~= nil
-    })
+    tested.assert({ given = "test with {expected='FAIL'} that fails", should = "appear as CFMT_TEST EXPECTED_FAIL", expected = true, actual = out:find("CFMT_TEST EXPECTED_FAIL") ~= nil })
+    tested.assert({ given = "test with {expected='EXCEPTION'} that throws", should = "appear as CFMT_TEST EXPECTED_EXCEPTION", expected = true, actual = out:find("CFMT_TEST EXPECTED_EXCEPTION") ~= nil })
+    tested.assert({ given = "test with {expected='FAIL'} that passes", should = "appear as CFMT_TEST UNEXPECTED", expected = true, actual = out:find("CFMT_TEST UNEXPECTED") ~= nil })
 end)
 
 return tested

--- a/tests/custom_formatter_test.lua
+++ b/tests/custom_formatter_test.lua
@@ -1,0 +1,176 @@
+local tested = require("tested")
+
+local TESTED = "tested"
+local FORMATTER = "tests/simple_formatter.lua"
+
+local function run(test_file)
+    local cmd = TESTED .. " -n 0 -z " .. FORMATTER .. " " .. test_file .. " 2>&1"
+    local handle = io.popen(cmd)
+    local out = handle:read("*a")
+    handle:close()
+    return out
+end
+
+-- header()
+
+tested.test("header line appears in output", function()
+    local out = run("tests/fully_working_test.lua")
+    tested.assert({
+        given = "custom formatter output",
+        should = "contain CFMT_HEADER line",
+        expected = true,
+        actual = out:find("CFMT_HEADER") ~= nil
+    })
+end)
+
+tested.test("header contains the test filename", function()
+    local out = run("tests/fully_working_test.lua")
+    tested.assert({
+        given = "CFMT_HEADER line",
+        should = "contain the test file path",
+        expected = true,
+        actual = out:find("fully_working_test%.lua") ~= nil
+    })
+end)
+
+tested.test("header contains the tested version", function()
+    local out = run("tests/fully_working_test.lua")
+    tested.assert({
+        given = "CFMT_HEADER line",
+        should = "contain 'tested v'",
+        expected = true,
+        actual = out:find("tested v") ~= nil
+    })
+end)
+
+-- results() — file section and PASS
+
+tested.test("file section line appears with correct filename", function()
+    local out = run("tests/fully_working_test.lua")
+    tested.assert({
+        given = "results output",
+        should = "contain CFMT_FILE with filename",
+        expected = true,
+        actual = out:find("CFMT_FILE tests/fully_working_test%.lua") ~= nil
+    })
+end)
+
+tested.test("each passing test gets a CFMT_TEST PASS line", function()
+    local out = run("tests/fully_working_test.lua")
+    tested.assert({
+        given = "first test in fully_working_test.lua",
+        should = "appear as CFMT_TEST PASS",
+        expected = true,
+        actual = out:find("CFMT_TEST PASS just works!") ~= nil
+    })
+    tested.assert({
+        given = "second test in fully_working_test.lua",
+        should = "appear as CFMT_TEST PASS",
+        expected = true,
+        actual = out:find("CFMT_TEST PASS just works without given and should!") ~= nil
+    })
+end)
+
+-- results() — skip variants
+
+tested.test("run_when=false test appears as CFMT_TEST CONDITIONAL_SKIP", function()
+    -- tested_test.tl contains: tested.test("conditional guy should be skipped", {run_when=false}, ...)
+    local out = run("tests/tested_test.tl")
+    tested.assert({
+        given = "test with run_when=false",
+        should = "appear as CFMT_TEST CONDITIONAL_SKIP",
+        expected = true,
+        actual = out:find("CFMT_TEST CONDITIONAL_SKIP conditional guy should be skipped") ~= nil
+    })
+end)
+
+-- results() — expected result types
+
+tested.test("expected-fail test appears as CFMT_TEST EXPECTED_FAIL", function()
+    local out = run("tests/expected_test.tl")
+    tested.assert({
+        given = "test with {expected='FAIL'} that fails",
+        should = "appear as CFMT_TEST EXPECTED_FAIL",
+        expected = true,
+        actual = out:find("CFMT_TEST EXPECTED_FAIL") ~= nil
+    })
+end)
+
+tested.test("expected-exception test appears as CFMT_TEST EXPECTED_EXCEPTION", function()
+    local out = run("tests/expected_test.tl")
+    tested.assert({
+        given = "test with {expected='EXCEPTION'} that throws",
+        should = "appear as CFMT_TEST EXPECTED_EXCEPTION",
+        expected = true,
+        actual = out:find("CFMT_TEST EXPECTED_EXCEPTION") ~= nil
+    })
+end)
+
+tested.test("test that doesn't match its expected result appears as CFMT_TEST UNEXPECTED", function()
+    local out = run("tests/expected_test.tl")
+    tested.assert({
+        given = "test with {expected='FAIL'} that passes",
+        should = "appear as CFMT_TEST UNEXPECTED",
+        expected = true,
+        actual = out:find("CFMT_TEST UNEXPECTED") ~= nil
+    })
+end)
+
+-- summary()
+
+tested.test("summary line appears in output", function()
+    local out = run("tests/fully_working_test.lua")
+    tested.assert({
+        given = "custom formatter output",
+        should = "contain CFMT_SUMMARY line",
+        expected = true,
+        actual = out:find("CFMT_SUMMARY") ~= nil
+    })
+end)
+
+tested.test("summary shows correct total and passed counts for all-passing run", function()
+    local out = run("tests/fully_working_test.lua")
+    -- fully_working_test.lua has exactly 2 passing tests
+    tested.assert({
+        given = "CFMT_SUMMARY for fully_working_test.lua",
+        should = "show total=2",
+        expected = true,
+        actual = out:find("total=2") ~= nil
+    })
+    tested.assert({
+        given = "CFMT_SUMMARY for fully_working_test.lua",
+        should = "show passed=2",
+        expected = true,
+        actual = out:find("passed=2") ~= nil
+    })
+    tested.assert({
+        given = "CFMT_SUMMARY for fully_working_test.lua",
+        should = "show failed=0",
+        expected = true,
+        actual = out:find("failed=0") ~= nil
+    })
+end)
+
+tested.test("summary shows non-zero failed count when tests fail", function()
+    -- tested_test.tl has known failing tests (sum() fails several assertions)
+    local out = run("tests/tested_test.tl")
+    tested.assert({
+        given = "CFMT_SUMMARY for tested_test.tl",
+        should = "show failed > 0",
+        expected = false,
+        actual = out:find("failed=0") ~= nil
+    })
+end)
+
+tested.test("summary skipped count reflects conditional skips", function()
+    -- tested_test.tl has one run_when=false test → skipped=1
+    local out = run("tests/tested_test.tl")
+    tested.assert({
+        given = "CFMT_SUMMARY for tested_test.tl",
+        should = "show skipped=1",
+        expected = true,
+        actual = out:find("skipped=1") ~= nil
+    })
+end)
+
+return tested

--- a/tests/exit_test.lua
+++ b/tests/exit_test.lua
@@ -1,0 +1,46 @@
+local tested = require("tested")
+
+-- Natural completion with no assertions: expect UNKNOWN
+tested.test("natural completion - no assertions", {expected="UNKNOWN"}, function()
+    local x = 1 + 1
+end)
+
+-- error() unhandled: pcall in tested catches it → EXCEPTION
+tested.test("unhandled error() call", {expected="EXCEPTION"}, function()
+    error("something went wrong")
+end)
+
+-- Lua assert() with nil: same as error() under the hood → EXCEPTION
+tested.test("assert() with nil condition", {expected="EXCEPTION"}, function()
+    local file = io.open("/nonexistent/path/file.txt", "r")
+    assert(file, "could not open file")
+end)
+
+-- Indexing nil: runtime error, pcall catches it → EXCEPTION
+tested.test("nil indexing runtime crash", {expected="EXCEPTION"}, function()
+    local a = nil
+    print(a.value)
+end)
+
+-- load() returns nil + message for bad syntax; calling nil is itself a runtime error → EXCEPTION
+tested.test("calling result of load() with syntax error", {expected="EXCEPTION"}, function()
+    local chunk = load("if true print('hello') end")
+    chunk()
+end)
+
+-- error() with a table value: pcall catches it but the error object is not a string
+tested.test("error() with non-string table object", {expected="EXCEPTION"}, function()
+    error({ code = 42, msg = "structured error" })
+end)
+
+-- os.exit() is now intercepted and raised as an error so tested can report it.
+tested.test("os.exit(0) terminates the host process", {expected="EXCEPTION"}, function()
+    os.exit(0)
+end)
+
+-- os.exit() is now intercepted and raised as an error so tested can report it.
+tested.test("os.exit() terminates the host process", {expected="EXCEPTION"}, function()
+    os.exit()
+end)
+
+return tested

--- a/tests/for_loops.tl
+++ b/tests/for_loops.tl
@@ -1,0 +1,33 @@
+local tested = require("tested")
+
+-- 1000 individual tests: most pass, a few fail sporadically (multiples of 97)
+for i = 1, 1000 do
+    tested.test("test #" .. i, function()
+        local expected = i * 2
+        -- fail at multiples of 97 by returning wrong value
+        local actual = (i % 97 == 0) and (expected + 1) or expected
+        tested.assert({
+            given = "i = " .. i,
+            should = "double i",
+            expected = expected,
+            actual = actual,
+        })
+    end)
+end
+
+-- single test with 1000 asserts: fails sporadically (multiples of 113)
+tested.test("1000 asserts with sporadic failures", function()
+    for i = 1, 1000 do
+        local expected = i * i
+        -- fail at multiples of 113 by returning a wrong value
+        local actual = (i % 113 == 0) and (expected - 1) or expected
+        tested.assert({
+            given = "i = " .. i,
+            should = "square i",
+            expected = expected,
+            actual = actual,
+        })
+    end
+end)
+
+return tested

--- a/tests/lifecycle_broken_before.lua
+++ b/tests/lifecycle_broken_before.lua
@@ -1,0 +1,17 @@
+local tested = require("tested")
+
+-- before_fn is called without pcall in tested:run(), so this error unwinds
+-- through run_with_cleanup() with no catch — none of the tests below will run.
+tested.before(function()
+    error("before hook is broken")
+end)
+
+tested.test("this test never runs", function()
+    tested.assert({ expected = true, actual = true })
+end)
+
+tested.test("neither does this one", function()
+    tested.assert({ expected = 1, actual = 1 })
+end)
+
+return tested

--- a/tests/simple_formatter.lua
+++ b/tests/simple_formatter.lua
@@ -1,0 +1,25 @@
+local formatter = {}
+
+formatter.format = "simple"
+formatter.allow_filtering = false
+
+function formatter.header(version, filepaths, comments)
+    return "CFMT_HEADER " .. version .. " " .. table.concat(filepaths, "|") .. "\n"
+end
+
+function formatter.results(tested_result, _)
+    local lines = {"CFMT_FILE " .. tested_result.filename}
+    for _, test in ipairs(tested_result.tests) do
+        table.insert(lines, "CFMT_TEST " .. test.result .. " " .. test.name)
+    end
+    return table.concat(lines, "\n") .. "\n"
+end
+
+function formatter.summary(output)
+    return "CFMT_SUMMARY total=" .. output.total_tests
+        .. " passed=" .. output.total_counts.passed
+        .. " failed=" .. output.total_counts.failed
+        .. " skipped=" .. output.total_counts.skipped .. "\n"
+end
+
+return formatter


### PR DESCRIPTION
## Changes
- Can now output test results to files at the end of a run
- stack traces are a little nicer for errors that throw objects (stacktrace includes line numbers now!)
- ability to catch as many Lua exit patterns as possible

AI Disclosure: I was really hoping AI would be able to handle adding the file output, but even with prompting it could not re-use the existing formatter cleanly. In the end, I wrote most of the code for it and the docs. AI wrote many of the test cases and helped looking into the debug module. Also, AI _could not_ get to the bottom of the Lua 5.1/LuaJIT issue and I had to step in to debug it.

It truly does sometimes seem great and other times feel severely lacking. Like it can do easy tedious things, but not _think clearly_.