### PR TITLE
Support for tags in tests!

### DIFF
--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -49,15 +49,23 @@ jobs:
           luarocks make
           luarocks install luacov-coveralls
 
-      - name: Run tests (sequentially)
+      - name: Run demo tests (sequentially)
         continue-on-error: true
         run: |
-          tested -c -n 0
+          tested -c -n 0 -t "demo"
+
+      - name: Run demo tests (parallel)
+        continue-on-error: true
+        run: |
+          tested -c -t "demo"
+
+      - name: Run tests (sequentially)
+        run: |
+          tested -c -n 0 -t "not demo"
 
       - name: Run tests (parallel)
-        continue-on-error: true
         run: |
-          tested -c
+          tested -c -t "not demo"
 
       - name: Save Cache
         uses: actions/cache/save@v5
@@ -102,17 +110,27 @@ jobs:
           luarocks make
           luarocks install luacov-coveralls
 
-      - name: Run tests (sequentially)
+      - name: Run demo tests (sequentially)
         continue-on-error: true
         run: |
           .\lua_install\bin\activate
-          tested -c -n 0
+          tested -c -n 0 -t "demo"
+
+      - name: Run demo tests (parallel)
+        continue-on-error: true
+        run: |
+          .\lua_install\bin\activate
+          tested -c -t "demo"
+
+      - name: Run tests (sequentially)
+        run: |
+          .\lua_install\bin\activate
+          tested -c -n 0 -t "not demo"
 
       - name: Run tests (parallel)
-        continue-on-error: true
         run: |
           .\lua_install\bin\activate
-          tested -c
+          tested -c -t "not demo"
 
       - name: Save Cache
         uses: actions/cache/save@v5

--- a/build/tested.lua
+++ b/build/tested.lua
@@ -21,6 +21,20 @@ local function validate_options(test_name, options, test_src)
          error(error_prefix .. "options.run_when takes in a 'boolean', but received '" .. type(options.run_when) .. "'", 0)
       end
    end
+
+   if options.tags ~= nil then
+      if type(options.tags) ~= "table" then
+         error(error_prefix .. "options.tags takes in a '{string}', but received '" .. type(options.tags) .. "'", 0)
+      end
+      for i, tag in ipairs(options.tags) do
+         if type(tag) ~= "string" then
+            error(error_prefix .. "options.tags[" .. i .. "] should be a 'string', but received '" .. type(tag) .. "'", 0)
+         end
+         if tag == "and" or tag == "or" or tag == "not" then
+            error(error_prefix .. "options.tags[" .. i .. "] appears to be a reserved keyword: 'and', 'or', or 'not'. Please change to a different tag name", 0)
+         end
+      end
+   end
 end
 
 local function extract_fn_and_options(test_name, fn_or_options, fn, test_src)
@@ -158,6 +172,17 @@ local function should_skip_test(test, run_only, options)
       return "SKIP", "Test marked with 'tested.skip'"
    elseif options and options.filter ~= nil and not string.find(test.name, options.filter) then
       return "CONDITIONAL_SKIP", "Test name does not match filter pattern '" .. options.filter .. "'"
+   elseif options and options.tags_filter ~= nil then
+
+      local tag_set = {}
+      if test.options.tags then
+         for _, tag in ipairs(test.options.tags) do tag_set[tag] = true end
+      end
+
+      if not options.tags_filter(tag_set) then
+         return "CONDITIONAL_SKIP", "Test tags do not match tag filter expression"
+      end
+
    elseif test.options.run_when ~= nil and test.options.run_when == false then
       return "CONDITIONAL_SKIP", "Condition in `tested.conditional_skip` returned false. Skipping test."
    end

--- a/build/tested.lua
+++ b/build/tested.lua
@@ -168,10 +168,16 @@ end
 local function should_skip_test(test, run_only, options)
    if run_only and test.kind ~= "only" then
       return "SKIP", "Only running 'tested.only' tests"
+
    elseif test.kind == "skip" then
       return "SKIP", "Test marked with 'tested.skip'"
+
+   elseif test.options.run_when ~= nil and test.options.run_when == false then
+      return "CONDITIONAL_SKIP", "Condition in `tested.conditional_skip` returned false. Skipping test."
+
    elseif options and options.filter ~= nil and not string.find(test.name, options.filter) then
       return "CONDITIONAL_SKIP", "Test name does not match filter pattern '" .. options.filter .. "'"
+
    elseif options and options.tags_filter ~= nil then
 
       local tag_set = {}
@@ -182,9 +188,6 @@ local function should_skip_test(test, run_only, options)
       if not options.tags_filter(tag_set) then
          return "CONDITIONAL_SKIP", "Test tags do not match tag filter expression"
       end
-
-   elseif test.options.run_when ~= nil and test.options.run_when == false then
-      return "CONDITIONAL_SKIP", "Condition in `tested.conditional_skip` returned false. Skipping test."
    end
    return nil, nil
 end

--- a/build/tested/cli.lua
+++ b/build/tested/cli.lua
@@ -51,6 +51,8 @@ local cli = { CLIOptions = {} }
 
 
 
+
+
 local cli_to_display = {
    ["skip"] = "SKIP",
    ["pass"] = "PASS",
@@ -71,6 +73,8 @@ function cli.parse_args(version)
    default(false)
    parser:option("-F --filter"):
    description("Only run tests whose name matches this Lua pattern (default: not-set)")
+   parser:option("-t --tags"):
+   description("Only run tests matching a tag expression, e.g. 'integration' or '(unit or integration) and not slow' (default: not-set)")
    parser:option("-s --show"):
    description("What test results to display (default: '-s fail -s exception -s unknown')"):
    choices({ "all", "valid", "invalid", "skip", "pass", "fail", "exception", "unknown", "expected", "unexpected" }):
@@ -148,6 +152,24 @@ function cli.validate_args(args)
       if not ok then
          error("Invalid --filter pattern '" .. args.filter .. "': " .. tostring(err), 0)
       end
+   end
+   if args.tags then
+      if args.tags:match("[^a-zA-Z0-9_ ()]") then
+         error("Invalid --tags expression: only letters, digits, underscores, spaces, and parentheses are allowed", 0)
+      end
+      local lua_expr = (args.tags:gsub("([a-zA-Z_][a-zA-Z0-9_]*)", function(word)
+         if word == "and" or word == "or" or word == "not" then return word end
+         return 'tags["' .. word .. '"]'
+      end))
+      local tag_filter = "local tags = ... \nreturn " .. lua_expr
+
+
+      local string_loader = loadstring or load
+      local loaded = string_loader(tag_filter)
+      if not loaded then
+         error("Invalid --tags expression '" .. args.tags .. "': Be sure to use boolean expressions ('or', 'and', 'not', etc) when combining tags", 0)
+      end
+      args.tags_filter = loaded
    end
 end
 

--- a/build/tested/main.lua
+++ b/build/tested/main.lua
@@ -104,6 +104,7 @@ local function run_tests(formatter, args, test_files)
       random = args.random,
       coverage = args.coverage,
       filter = args.filter,
+      tags_filter = args.tags_filter,
    }
 
    local display_results = function(test_output)
@@ -165,6 +166,9 @@ local function main()
    local header_comments = {}
    if args.filter ~= nil then
       table.insert(header_comments, "Filtering tests with pattern: '" .. args.filter .. "'")
+   end
+   if args.tags ~= nil then
+      table.insert(header_comments, "Filtering tests with tag expression: '" .. args.tags .. "'")
    end
 
 

--- a/build/tested/types.lua
+++ b/build/tested/types.lua
@@ -160,4 +160,6 @@ local types = {}
 
 
 
+
+
 return types

--- a/src/tested.tl
+++ b/src/tested.tl
@@ -168,10 +168,16 @@ end
 local function should_skip_test(test: types.Test, run_only: boolean, options: types.TestRunnerOptions): types.TestResult, string
    if run_only and test.kind ~= "only" then
       return "SKIP", "Only running 'tested.only' tests"
+
    elseif test.kind == "skip" then
       return "SKIP", "Test marked with 'tested.skip'"
+
+   elseif test.options.run_when ~= nil and test.options.run_when == false then
+      return "CONDITIONAL_SKIP", "Condition in `tested.conditional_skip` returned false. Skipping test."
+
    elseif options and options.filter ~= nil and not string.find(test.name, options.filter) then
       return "CONDITIONAL_SKIP", "Test name does not match filter pattern '" .. options.filter .. "'"
+
    elseif options and options.tags_filter ~= nil then
       -- only need to create if tags have been set
       local tag_set: {string: boolean} = {}
@@ -182,9 +188,6 @@ local function should_skip_test(test: types.Test, run_only: boolean, options: ty
       if not options.tags_filter(tag_set) then
          return "CONDITIONAL_SKIP", "Test tags do not match tag filter expression"
       end
-
-   elseif test.options.run_when ~= nil and test.options.run_when == false then
-      return "CONDITIONAL_SKIP", "Condition in `tested.conditional_skip` returned false. Skipping test."
    end
    return nil, nil  -- not a skip
 end

--- a/src/tested.tl
+++ b/src/tested.tl
@@ -21,6 +21,20 @@ local function validate_options(test_name: string, options: types.TestedOptions,
          error(error_prefix .. "options.run_when takes in a 'boolean', but received '" .. type(options.run_when) .. "'", 0)
       end
    end
+
+   if options.tags ~= nil then
+      if type(options.tags) ~= "table" then
+         error(error_prefix .. "options.tags takes in a '{string}', but received '" .. type(options.tags) .. "'", 0)
+      end
+      for i, tag in ipairs(options.tags as {string}) do
+         if type(tag) ~= "string" then
+            error(error_prefix .. "options.tags[" .. i .. "] should be a 'string', but received '" .. type(tag) .. "'", 0)
+         end
+         if tag == "and" or tag == "or" or tag == "not" then
+            error(error_prefix .. "options.tags[" .. i .. "] appears to be a reserved keyword: 'and', 'or', or 'not'. Please change to a different tag name", 0)
+         end
+      end
+   end
 end
 
 local function extract_fn_and_options(test_name: string, fn_or_options: function() | types.TestedOptions, fn?: function(), test_src?: string): function(), types.TestedOptions
@@ -158,6 +172,17 @@ local function should_skip_test(test: types.Test, run_only: boolean, options: ty
       return "SKIP", "Test marked with 'tested.skip'"
    elseif options and options.filter ~= nil and not string.find(test.name, options.filter) then
       return "CONDITIONAL_SKIP", "Test name does not match filter pattern '" .. options.filter .. "'"
+   elseif options and options.tags_filter ~= nil then
+      -- only need to create if tags have been set
+      local tag_set: {string: boolean} = {}
+      if test.options.tags then
+         for _, tag in ipairs(test.options.tags) do tag_set[tag] = true end
+      end
+
+      if not options.tags_filter(tag_set) then
+         return "CONDITIONAL_SKIP", "Test tags do not match tag filter expression"
+      end
+
    elseif test.options.run_when ~= nil and test.options.run_when == false then
       return "CONDITIONAL_SKIP", "Condition in `tested.conditional_skip` returned false. Skipping test."
    end

--- a/src/tested/cli.tl
+++ b/src/tested/cli.tl
@@ -38,11 +38,13 @@ local record cli
       debug: logging.level
       threads: integer
       filter: string
+      tags: string
 
       -- derived from above values
       test_files: {string}
       test_directories: {string}
       specified_show: boolean
+      tags_filter: function(tags: {string:boolean}): boolean
    end
 
    parse_args: function(string): cli.CLIOptions
@@ -71,6 +73,8 @@ function cli.parse_args(version: string): cli.CLIOptions
       :default(false)
    parser:option("-F --filter")
       :description("Only run tests whose name matches this Lua pattern (default: not-set)")
+   parser:option("-t --tags")
+      :description("Only run tests matching a tag expression, e.g. 'integration' or '(unit or integration) and not slow' (default: not-set)")
    parser:option("-s --show")
       :description("What test results to display (default: '-s fail -s exception -s unknown')")
       :choices({"all", "valid", "invalid", "skip", "pass", "fail", "exception", "unknown", "expected", "unexpected"})
@@ -148,6 +152,24 @@ function cli.validate_args(args: cli.CLIOptions)
       if not ok then
          error("Invalid --filter pattern '" .. args.filter .. "': " .. tostring(err), 0)
       end
+   end
+   if args.tags then
+      if args.tags:match("[^a-zA-Z0-9_ ()]") then
+         error("Invalid --tags expression: only letters, digits, underscores, spaces, and parentheses are allowed", 0)
+      end
+      local lua_expr = (args.tags:gsub("([a-zA-Z_][a-zA-Z0-9_]*)", function(word: string): string
+         if word == "and" or word == "or" or word == "not" then return word end
+         return 'tags["' .. word .. '"]'
+      end))
+      local tag_filter = "local tags = ... \nreturn " .. lua_expr
+
+      global loadstring: function(string): function(), string
+      local string_loader = loadstring or load
+      local loaded = string_loader(tag_filter)
+      if not loaded then
+         error("Invalid --tags expression '" .. args.tags .. "': Be sure to use boolean expressions ('or', 'and', 'not', etc) when combining tags", 0)
+      end
+      args.tags_filter = loaded
    end
 end
 

--- a/src/tested/main.tl
+++ b/src/tested/main.tl
@@ -103,7 +103,8 @@ local function run_tests(formatter: types.ResultFormatter, args: cli.CLIOptions,
    local options: types.TestRunnerOptions = {
       random = args.random,
       coverage = args.coverage,
-      filter = args.filter
+      filter = args.filter,
+      tags_filter = args.tags_filter
    }
 
    local display_results = function(test_output: types.TestedOutput)
@@ -165,6 +166,9 @@ local function main()
    local header_comments: {string} = {}
    if args.filter ~= nil then
       table.insert(header_comments, "Filtering tests with pattern: '" .. args.filter .. "'")
+   end
+   if args.tags ~= nil then
+      table.insert(header_comments, "Filtering tests with tag expression: '" .. args.tags .. "'")
    end
 
    -- running the tests

--- a/src/tested/types.tl
+++ b/src/tested/types.tl
@@ -12,6 +12,7 @@ local record types
       random: boolean
       coverage: boolean
       filter: string
+      tags_filter: function(tags: {string:boolean}): boolean
    end
 
    enum TestResult
@@ -132,6 +133,7 @@ local record types
       -- retry_timeout: number
       expected: ExpectedTestResult
       run_when: boolean
+      tags: {string}
    end
 
    interface Tested

--- a/tested-dev-1.rockspec
+++ b/tested-dev-1.rockspec
@@ -57,27 +57,8 @@ build = {
          'src/bin/tested'
       },
       lua = {
+         -- could also maybe swap out with a .d.tl for _unlimited speed_
          "src/tested.tl",
-
-         ["tested.assert_table"] = "src/tested/assert_table.tl",
-         ["tested.cli"] = "src/tested/cli.tl",
-         ["tested.file_loader"] = "src/tested/file_loader.tl",
-         ["tested.main"] = "src/tested/main.tl",
-         ["tested.test_runner"] = "src/tested/test_runner.tl",
-         ["tested.types"] = "src/tested/types.tl",
-
-         ["tested.libs.ansicolors"] = "src/tested/libs/ansicolors.tl",
-         ["tested.libs.inspect"] = "src/tested/libs/inspect.tl",
-         ["tested.libs.logging"] = "src/tested/libs/logging.tl",
-         ["tested.libs.tadd"] = "src/tested/libs/tadd.tl",
-         ["tested.libs.ThreadPool"] = "src/tested/libs/ThreadPool.tl",
-
-         ["tested.file_output.txt"] = "src/tested/file_output/txt.tl",
-         ["tested.file_output.json"] = "src/tested/file_output/json.tl",
-
-         ["tested.results.plain"] = "src/tested/results/plain.tl",
-         ["tested.results.tap"] = "src/tested/results/tap.tl",
-         ["tested.results.terminal"] = "src/tested/results/terminal.tl",
       }
    }
 }

--- a/tests/expected_test.tl
+++ b/tests/expected_test.tl
@@ -25,7 +25,7 @@ end)
 
 -- === UNEXPECTED: expected FAIL but test passes ===
 -- A test expected to fail that actually passes → UNEXPECTED
-tested.test("unexpected: expected fail but test passes", {expected="FAIL"}, function()
+tested.test("unexpected: expected fail but test passes", {expected="FAIL", tags={"demo"}}, function()
    tested.assert({
       given = "1 + 1",
       should = "equal 2",
@@ -36,7 +36,7 @@ end)
 
 -- === UNEXPECTED: expected EXCEPTION but no exception thrown ===
 -- A test expected to throw that completes normally → UNEXPECTED
-tested.test("unexpected: expected exception but no exception thrown", {expected="EXCEPTION"}, function()
+tested.test("unexpected: expected exception but no exception thrown", {expected="EXCEPTION", tags={"demo"}}, function()
    tested.assert({
       given = "1 + 1",
       should = "equal 2",
@@ -47,7 +47,7 @@ end)
 
 -- === UNEXPECTED: expected UNKNOWN but assertions were run ===
 -- A test expected to be unknown that does run assertions → UNEXPECTED
-tested.test("unexpected: expected unknown but assertions were run", {expected="UNKNOWN"}, function()
+tested.test("unexpected: expected unknown but assertions were run", {expected="UNKNOWN", tags={"demo"}}, function()
    tested.assert({
       given = "1 + 1",
       should = "equal 2",

--- a/tests/for_loops.tl
+++ b/tests/for_loops.tl
@@ -2,7 +2,7 @@ local tested = require("tested")
 
 -- 1000 individual tests: most pass, a few fail sporadically (multiples of 97)
 for i = 1, 1000 do
-    tested.test("test #" .. i, function()
+    tested.test("test #" .. i, {tags={"demo"}}, function()
         local expected = i * 2
         -- fail at multiples of 97 by returning wrong value
         local actual = (i % 97 == 0) and (expected + 1) or expected
@@ -16,7 +16,7 @@ for i = 1, 1000 do
 end
 
 -- single test with 1000 asserts: fails sporadically (multiples of 113)
-tested.test("1000 asserts with sporadic failures", function()
+tested.test("1000 asserts with sporadic failures", {tags={"demo"}}, function()
     for i = 1, 1000 do
         local expected = i * i
         -- fail at multiples of 113 by returning a wrong value

--- a/tests/non_working_test.tl
+++ b/tests/non_working_test.tl
@@ -10,7 +10,7 @@ tested.test("doesn't work with given and should being not strings!", function()
 end)
 
 
-tested.test("output should clearly show just given", function()
+tested.test("output should clearly show just given", {tags={"demo"}}, function()
 	tested.assert({
 		given="true",
 		expected=false,
@@ -18,7 +18,7 @@ tested.test("output should clearly show just given", function()
 	})
 end)
 
-tested.test("output should clearly show just should", function()
+tested.test("output should clearly show just should", {tags={"demo"}}, function()
 	tested.assert({
 		should="true",
 		expected=true,

--- a/tests/tables_test.tl
+++ b/tests/tables_test.tl
@@ -23,7 +23,7 @@ local t3 = {
   config = { debug = true, port = 8080, crazy_table = {"hello", "world"} }
 }
 
-tested.test("table compare will error", function()
+tested.test("table compare will error", {expected="FAIL"}, function()
   tested.assert({
     given = "a basic table",
     should = "not be the same as the other table",
@@ -58,7 +58,7 @@ tested.test("tables with self-cycles, but the same structure should be equal", f
    })
 end)
 
-tested.test("slightly complicated tables with self-cycles, but with different structures should not be equal", function()
+tested.test("slightly complicated tables with self-cycles, but with different structures should not be equal", {expected="FAIL"}, function()
 
    local cycle_a: {any:any} = {}
    cycle_a[1] = "first"
@@ -161,7 +161,7 @@ tested.test("tables with matching __eq should be considered equal", function()
    })
 end)
 
-tested.test("tables with non-matching __eq should be considered not equal", function()
+tested.test("tables with non-matching __eq should not be considered not equal", {expected="FAIL"}, function()
    -- __eq returning false should still produce a failure, not a deep-field diff
    local p3 = setmetatable({x=1, y=2} as Point, point_mt)
    local p4 = setmetatable({x=9, y=9} as Point, point_mt)
@@ -194,7 +194,7 @@ tested.test("container table whose nested field has matching __eq should be equa
    })
 end)
 
-tested.test("container table whose nested field has non-matching __eq should not be equal", function()
+tested.test("container table whose nested field has non-matching __eq should not be equal", {expected="FAIL"}, function()
    tested.assert({
       given = "two shapes whose center Points have different coordinates",
       should = "not be equal because the nested Point's __eq returns false",

--- a/tests/tags_test.tl
+++ b/tests/tags_test.tl
@@ -1,0 +1,23 @@
+local tested = require("tested")
+
+tested.test("tagged as unit", {tags={"unit"}}, function()
+   tested.assert({given="1+1", should="equal 2", expected=2, actual=1+1})
+end)
+
+tested.test("tagged as integration", {tags={"integration"}}, function()
+   tested.assert({given="1+1", should="equal 2", expected=2, actual=1+1})
+end)
+
+tested.test("tagged as unit and slow", {tags={"unit", "slow"}}, function()
+   tested.assert({given="1+1", should="equal 2", expected=2, actual=1+1})
+end)
+
+tested.test("tagged as integration and slow", {tags={"integration", "slow"}}, function()
+   tested.assert({given="1+1", should="equal 2", expected=2, actual=1+1})
+end)
+
+tested.test("no tags", function()
+   tested.assert({given="1+1", should="equal 2", expected=2, actual=1+1})
+end)
+
+return tested

--- a/tests/tested_test.tl
+++ b/tests/tested_test.tl
@@ -5,7 +5,7 @@ local function sum(a: number, b: number): number
 end
 
 -- Your test code (unchanged)
-tested.test("sum()", function()
+tested.test("sum()", {tags={"demo"}}, function()
     
     -- some setup could go here!
     -- this should be run before every assert!
@@ -58,7 +58,7 @@ tested.test("just a test!", function()
     })
 end)
 
-tested.test("Throws exception in assert", function()
+tested.test("Throws exception in assert", {tags={"demo"}}, function()
     tested.assert({
         given = "2 + 2",
         should = "raise unhandled excpetion!",
@@ -83,6 +83,6 @@ tested.test("assert_throws_exception handles exception in assert", function()
     })
 end)
 
-tested.test("should return unknown since no tested.assert called", function() end)
+tested.test("should return unknown since no tested.assert called", {tags={"demo"}}, function() end)
 
 return tested


### PR DESCRIPTION
## Changes
- Added support for test tags and filtering them with some boolean logic!
- Also, am now filtering `tested`'s test suite with tags

AI Disclosure: For a lot of what I've done, I wrote the bulk of the feature and had AI finish up the tedious work. For this one I _tried_ to get AI to write it all. It was able to modify the CLI acceptably, but then was duplicating code, performing unnecessary actions, and introduced a bug in the skip order. I ended up scrapping most of what it wrote. However, it did write the new tests and update existing tests with tags.