### PR TITLE
Make Teal an optional dependency

### DIFF
--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Run demo tests (sequentially)
         continue-on-error: true
         run: |
-          tested -n 0 -t "demo"
+          luarocks test
 
       - name: Run demo tests (parallel)
         continue-on-error: true
@@ -119,7 +119,7 @@ jobs:
         continue-on-error: true
         run: |
           .\lua_install\bin\activate
-          tested -n 0 -t "demo"
+          luarocks test
 
       - name: Run demo tests (parallel)
         continue-on-error: true

--- a/build/tested/languages/teal.lua
+++ b/build/tested/languages/teal.lua
@@ -3,11 +3,13 @@
 local teal_handler = {}
 
 
+
+if not pcall(require, "tl") then error("Teal does not appear to be installed, unable to locate the 'tl' module. Teal support cannot be loaded.") end
+
 teal_handler.extension = ".tl"
 
 teal_handler.loader = function(filepath)
    local tl = require("tl")
-
    local file, err = io.open(filepath, "rb")
    if not file then error("Cannot load filepath: '" .. filepath .. "' with error: " .. err) end
    local file_contents = file:read("*all")

--- a/docs/index.md
+++ b/docs/index.md
@@ -147,4 +147,4 @@ There are a couple CLI commands that are good to know when you get started:
 To see the entire list of CLI options, check out the [CLI Reference](./cli.md)
 
 ### Teal Support
-`tested` has builtin Teal support, be sure to check out the [Teal Support](./teal-support.md) page for some of the considerations around its usage with Teal.
+`tested` has builtin Teal support, be sure to have Teal [installed](https://teal-language.org/#download) and check out the [Teal Support](./teal-support.md) page for some of the considerations around its usage with Teal.

--- a/docs/language-handlers.md
+++ b/docs/language-handlers.md
@@ -3,11 +3,13 @@
 
 
 ## Setting up a language handler
-Currently a new language hanlder involves creating a Lua table with the following attributes and returning it:
+Currently a new language handler involves creating a Lua table with the following attributes and returning it:
 
 - `extension: string` - a string representing the file extension
 - `loader: function(filepath: string): function(): any` - a function that can load the file. It should raise an error if something goes wrong, and return a loader function that when called, returns the module in Lua. This is for loading tests written in a different language.
 - `setup?: function()` - this is an optional method that gets run before tests get executed to support any language features that are needed for running a test itself.
+
+With some of the ideas in related to [better Teal file handling](./teal-support.md#good-to-know), some of the way language handlers work _could_ change.
 
 ### The loader
 The loader sets up loading files given the specific extension. Since it is designed for use with `tested` it can load [test files](./unit-testing.md#tests) or [custom formatters](./custom-formatter.md). Both are zero-argument loading from files that return tables. So any files written in another language would have to be setup that way as well.

--- a/docs/teal-support.md
+++ b/docs/teal-support.md
@@ -1,37 +1,15 @@
 # Teal Support
 
-`tested` is built from the ground up with with Teal and makes it a first class citizen. Unit tests can be written in Teal and all the functionality (including code coverage!) works across both languages wonderfully. However, there are a couple of things to keep in mind when using `tested` with Teal projects. 
+`tested` is built from the ground up with Teal and makes it a first class citizen. Be sure to have Teal [installed](https://teal-language.org/#download) when using `tested` with Teal so it will get auto-enabled. Unit tests can be written in Teal and all the functionality (including code coverage!) works across both languages wonderfully. However, there are a couple of things to keep in mind when using `tested` with Teal projects.
 
-## Build, then test if perf matters
-If you have a Teal project and are writing your unit tests in Teal, _every_ test file will compile the Teal as it gets loaded. However, it is worth knowing that `tested` will attmept to run the Teal files even if they are not typed correctly.
+## Good to know
+With the way Teal support has been added, `tl.loader()` gets called before running unit tests. This allows Teal files to be `require`'d if they are in the search path. `tl.loader()` adds the Teal package searcher into position two of `package.loaders`, which means if a Teal file and a Lua file are at the same path, the Teal file will be loaded first.
 
-Example Teal unit test:
-```lua
-local utf8validator = require("utf8validator") -- will compile the `utf8validator` module
-local tested = require("tested")
+This also means that even if you write your test in Lua, but have it referencing a Teal library, it will use the Teal version of that library. For many situations this might not matter, since they are functionally the same, but it does mean that the Teal version will be re-compiled once per test file, which _could_ cause some performance issues for large Teal test suites. To at least partially mitigate this, `tested` (currently) compiles Teal files, but is set to not type-check them, to offer some time savings.
 
-tested.test("should support ascii", function()
-   local start_seq = tonumber("00000000", 2)
-   local end_seq = tonumber("01111111", 2)
+So yeah, currently two problems around this:
 
-   for i = start_seq, end_seq do
-      tested.assert({
-      	given="string.char " .. i,
-      	should="support ascii char",
-      	expected=true,
-      	actual=utf8validator(string.char(i))
-      })
-   end
+1. Lua files can "accidentally" load Teal modules
+2. Teal files _always_ get re-compiled slowing down unit tests
 
-end)
-
-return tested
-```
-
-Assuming I had multiple unit test files that all pull in `utf8validator`, every one of them will re-compile the `utf8validator.tl` file, which can slow down the test suite. If this slowdown is of particular concern, you should instead compile your Teal code first **and write your test files in Lua**. It really depends on how large your Teal project is, how many test files you have, and how you interface with them.
-
-For example, if you are doing TDD, you may want to accept the performance loss and use Teal unit test files so that `tested` is _always_ using the Teal files as a source. If you have a large test suite where Lua benchmarking matters, it may make more sense to compile and then test.
-
-Another thing to keep in mind, if there is a Lua and Teal file in the Lua's instance search path with the same `require`-able name, the Lua file will be pulled in first.
-
-In the future, I may consider adding in some way to avoid that additional compilation, so any Teal modules only get compiled once, but it sort've goes against the ethos of unit testing (ie: tests should be isolated from one another) if `require`'d modules start being shared across files.
+If this is something you run into and is causing problems (or you have some ideas around it), [let us know](https://github.com/FourierTransformer/tested/issues/46) since we are considering some options there.

--- a/src/tested/languages/teal.tl
+++ b/src/tested/languages/teal.tl
@@ -3,11 +3,13 @@ local type types = require("tested.types")
 local record teal_handler is types.LanguageHandler
 end
 
+-- i am purposefully avoiding upvalues here. `setup` can really struggle with them due to it being run in all the worker threads.
+if not pcall(require, "tl") then error("Teal does not appear to be installed, unable to locate the 'tl' module. Teal support cannot be loaded.") end
+
 teal_handler.extension = ".tl"
 
 teal_handler.loader = function(filepath: string): function(): any
    local tl = require("tl")
-
    local file, err = io.open(filepath, "rb")
    if not file then error("Cannot load filepath: '" .. filepath .. "' with error: " .. err) end
    local file_contents = file:read("*all")

--- a/tested-0.2.0-1.rockspec
+++ b/tested-0.2.0-1.rockspec
@@ -19,10 +19,16 @@ dependencies = {
    "luafilesystem",
    "argparse",
    "luacov",
-   -- just use whatever version of tl they have installed
-   -- they'll likely install tl first and then tested, so seems like a safe bet
-   "tl", 
    "lanes==3.17.2"
+}
+
+test_dependencies = {
+   "tl"
+}
+
+test = {
+   type = "tested",
+   flags = { "-c", "-n", "0", "-f", "plain" }
 }
 
 build = {

--- a/tested-0.2.1-1.rockspec
+++ b/tested-0.2.1-1.rockspec
@@ -28,7 +28,7 @@ test_dependencies = {
 
 test = {
    type = "tested",
-   flags = { "-c", "-n", "0", "-f", "plain" }
+   flags = { "-n", "0", "-t", "demo" }
 }
 
 build = {

--- a/tested-0.2.1-1.rockspec
+++ b/tested-0.2.1-1.rockspec
@@ -1,12 +1,12 @@
 rockspec_format = "3.0"
 
 package = "tested"
-version = "0.2.0-1"
+version = "0.2.1-1"
 
 source = {
    url = "git+https://github.com/FourierTransformer/tested.git",
    branch = "main",
-   tag = "0.2.0"
+   tag = "0.2.1"
 }
 
 description = {


### PR DESCRIPTION
This was supposed to go in the last release, but forgot, so here we are! Teal is now optional and I really updated some of the issues with Teal support at the moment.

AI Disclosure: AI was not used to write any of the docs, but it did review them for correctness.