### PR TITLE
No longer clear out non-c modules between test files

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ Apart from dependencies specified in the rockspec, parts of the following are in
 - Also bundles a slightly modified [ansicolors.lua](https://github.com/kikito/ansicolors.lua) - MIT
 - A function from [Luacov](https://github.com/lunarmodules/luacov) code to help merge stats files in process - MIT
 - Bundles [dkjson.lua](https://dkolf.de/dkjson-lua/)'s encoder for writing file output to json - MIT
-- Uses a modified LuaRocks test loader - MIT
+- Bundles a polyfill for `package.searchpath` for Lua 5.1 from [Penlight](https://lunarmodules.github.io/Penlight/) - MIT
+- Uses a modified LuaRocks test loader to support `luarocks test` - MIT
 
 
 Major thanks to hishamhm, kikito, and benoit-germain for their work in the Lua space. Without them, `tested` wouldn't be possible.

--- a/build/tested/test_runner.lua
+++ b/build/tested/test_runner.lua
@@ -7,6 +7,46 @@ local logger = logging.get_logger("tested.test_runner")
 
 local test_runner = {}
 
+
+if not package.searchpath then
+   function package.searchpath(name, path, sep, rep)
+      if type(name) ~= "string" then
+         error(("bad argument #1 to 'searchpath' (string expected, got %s)"):format(type(path)), 2)
+      end
+      if type(path) ~= "string" then
+         error(("bad argument #2 to 'searchpath' (string expected, got %s)"):format(type(path)), 2)
+      end
+      if sep ~= nil and type(sep) ~= "string" then
+         error(("bad argument #3 to 'searchpath' (string expected, got %s)"):format(type(path)), 2)
+      end
+      if rep ~= nil and type(rep) ~= "string" then
+         error(("bad argument #4 to 'searchpath' (string expected, got %s)"):format(type(path)), 2)
+      end
+      sep = sep or "."
+      rep = rep or _G.package.config:sub(1, 1)
+      do
+         local s, e = name:find(sep, nil, true)
+         while s do
+            name = name:sub(1, s - 1) .. rep .. name:sub(e + 1, -1)
+            s, e = name:find(sep, s + #rep + 1, true)
+         end
+      end
+      local tried = {}
+      for m in path:gmatch('[^;]+') do
+         local nm = m:gsub('?', name)
+         tried[#tried + 1] = nm
+         local f = io.open(nm, 'r')
+         if f then f:close(); return nm end
+      end
+      return nil, "\tno file '" .. table.concat(tried, "'\n\tno file '") .. "'"
+   end
+end
+
+local function is_c_package(module_name)
+   if package.searchpath(module_name, package.cpath) then return true end
+   return false
+end
+
 function test_runner.run_with_cleanup(file_loader, test_file, options)
 
    logger:info("%s: keeping track of pre-loaded packages", test_file)
@@ -20,11 +60,15 @@ function test_runner.run_with_cleanup(file_loader, test_file, options)
 
    local test_results = test_module:run(test_file, options)
 
-   logger:info("%s: Clearing out any packages that were loaded", test_file)
+   logger:info("%s: Clearing out any Lua packages that were loaded", test_file)
    for package_name, _ in pairs(package.loaded) do
       if not pre_test_loaded_packages[package_name] then
-         logger:debug("%s: Clearing out package: %s", test_file, package_name)
-         package.loaded[package_name] = nil
+         if is_c_package(package_name) then
+            logger:debug("%s: NOT clearing out C module: %s", test_file, package_name)
+         else
+            logger:debug("%s: Clearing out package: %s", test_file, package_name)
+            package.loaded[package_name] = nil
+         end
       end
    end
    collectgarbage()

--- a/build/tested/test_runner.lua
+++ b/build/tested/test_runner.lua
@@ -60,7 +60,7 @@ function test_runner.run_with_cleanup(file_loader, test_file, options)
 
    local test_results = test_module:run(test_file, options)
 
-   logger:info("%s: Clearing out any Lua packages that were loaded", test_file)
+   logger:info("%s: Clearing out any non-C packages that were loaded", test_file)
    for package_name, _ in pairs(package.loaded) do
       if not pre_test_loaded_packages[package_name] then
          if is_c_package(package_name) then

--- a/build/tested/test_runner.lua
+++ b/build/tested/test_runner.lua
@@ -8,42 +8,41 @@ local logger = logging.get_logger("tested.test_runner")
 local test_runner = {}
 
 
-if not package.searchpath then
-   function package.searchpath(name, path, sep, rep)
-      if type(name) ~= "string" then
-         error(("bad argument #1 to 'searchpath' (string expected, got %s)"):format(type(path)), 2)
-      end
-      if type(path) ~= "string" then
-         error(("bad argument #2 to 'searchpath' (string expected, got %s)"):format(type(path)), 2)
-      end
-      if sep ~= nil and type(sep) ~= "string" then
-         error(("bad argument #3 to 'searchpath' (string expected, got %s)"):format(type(path)), 2)
-      end
-      if rep ~= nil and type(rep) ~= "string" then
-         error(("bad argument #4 to 'searchpath' (string expected, got %s)"):format(type(path)), 2)
-      end
-      sep = sep or "."
-      rep = rep or _G.package.config:sub(1, 1)
-      do
-         local s, e = name:find(sep, nil, true)
-         while s do
-            name = name:sub(1, s - 1) .. rep .. name:sub(e + 1, -1)
-            s, e = name:find(sep, s + #rep + 1, true)
-         end
-      end
-      local tried = {}
-      for m in path:gmatch('[^;]+') do
-         local nm = m:gsub('?', name)
-         tried[#tried + 1] = nm
-         local f = io.open(nm, 'r')
-         if f then f:close(); return nm end
-      end
-      return nil, "\tno file '" .. table.concat(tried, "'\n\tno file '") .. "'"
+
+local _searchpath = package.searchpath or function(name, path, sep, rep)
+   if type(name) ~= "string" then
+      error(("bad argument #1 to 'searchpath' (string expected, got %s)"):format(type(path)), 2)
    end
+   if type(path) ~= "string" then
+      error(("bad argument #2 to 'searchpath' (string expected, got %s)"):format(type(path)), 2)
+   end
+   if sep ~= nil and type(sep) ~= "string" then
+      error(("bad argument #3 to 'searchpath' (string expected, got %s)"):format(type(path)), 2)
+   end
+   if rep ~= nil and type(rep) ~= "string" then
+      error(("bad argument #4 to 'searchpath' (string expected, got %s)"):format(type(path)), 2)
+   end
+   sep = sep or "."
+   rep = rep or _G.package.config:sub(1, 1)
+   do
+      local s, e = name:find(sep, nil, true)
+      while s do
+         name = name:sub(1, s - 1) .. rep .. name:sub(e + 1, -1)
+         s, e = name:find(sep, s + #rep + 1, true)
+      end
+   end
+   local tried = {}
+   for m in path:gmatch('[^;]+') do
+      local nm = m:gsub('?', name)
+      tried[#tried + 1] = nm
+      local f = io.open(nm, 'r')
+      if f then f:close(); return nm end
+   end
+   return nil, "\tno file '" .. table.concat(tried, "'\n\tno file '") .. "'"
 end
 
 local function is_c_package(module_name)
-   if package.searchpath(module_name, package.cpath) then return true end
+   if _searchpath(module_name, package.cpath) then return true end
    return false
 end
 

--- a/src/tested/test_runner.tl
+++ b/src/tested/test_runner.tl
@@ -8,42 +8,41 @@ local logger = logging.get_logger("tested.test_runner")
 local record test_runner end
 
 -- from the indomitable Penlight - MIT
-if not package.searchpath then
-    function package.searchpath (name: string, path: string, sep: string, rep: string): string, string    -- luacheck: ignore
-        if type(name) ~= "string" then
-            error(("bad argument #1 to 'searchpath' (string expected, got %s)"):format(type(path)), 2)
-        end
-        if type(path) ~= "string" then
-            error(("bad argument #2 to 'searchpath' (string expected, got %s)"):format(type(path)), 2)
-        end
-        if sep ~= nil and type(sep) ~= "string" then
-            error(("bad argument #3 to 'searchpath' (string expected, got %s)"):format(type(path)), 2)
-        end
-        if rep ~= nil and type(rep) ~= "string" then
-            error(("bad argument #4 to 'searchpath' (string expected, got %s)"):format(type(path)), 2)
-        end
-        sep = sep or "."
-        rep = rep or _G.package.config:sub(1,1)
-        do
-          local s, e = name:find(sep, nil, true)
-          while s do
-            name = name:sub(1, s-1) .. rep .. name:sub(e+1, -1)
-            s, e = name:find(sep, s + #rep + 1, true)
-          end
-        end
-        local tried = {}
-        for m in path:gmatch('[^;]+') do
-            local nm = m:gsub('?', name)
-            tried[#tried+1] = nm
-            local f = io.open(nm,'r')
-            if f then f:close(); return nm end
-        end
-        return nil, "\tno file '" .. table.concat(tried, "'\n\tno file '") .. "'"
-    end
-end
+-- turned into an upvalue so it can be available in Lanes properly
+local _searchpath = package.searchpath or function (name: string, path: string, sep: string, rep: string): string, string    -- luacheck: ignore
+     if type(name) ~= "string" then
+         error(("bad argument #1 to 'searchpath' (string expected, got %s)"):format(type(path)), 2)
+     end
+     if type(path) ~= "string" then
+         error(("bad argument #2 to 'searchpath' (string expected, got %s)"):format(type(path)), 2)
+     end
+     if sep ~= nil and type(sep) ~= "string" then
+         error(("bad argument #3 to 'searchpath' (string expected, got %s)"):format(type(path)), 2)
+     end
+     if rep ~= nil and type(rep) ~= "string" then
+         error(("bad argument #4 to 'searchpath' (string expected, got %s)"):format(type(path)), 2)
+     end
+     sep = sep or "."
+     rep = rep or _G.package.config:sub(1,1)
+     do
+       local s, e = name:find(sep, nil, true)
+       while s do
+         name = name:sub(1, s-1) .. rep .. name:sub(e+1, -1)
+         s, e = name:find(sep, s + #rep + 1, true)
+       end
+     end
+     local tried = {}
+     for m in path:gmatch('[^;]+') do
+         local nm = m:gsub('?', name)
+         tried[#tried+1] = nm
+         local f = io.open(nm,'r')
+         if f then f:close(); return nm end
+     end
+     return nil, "\tno file '" .. table.concat(tried, "'\n\tno file '") .. "'"
+ end
 
 local function is_c_package(module_name: string): boolean
-   if package.searchpath(module_name, package.cpath) then return true end
+   if _searchpath(module_name, package.cpath) then return true end
    return false
 end
 

--- a/src/tested/test_runner.tl
+++ b/src/tested/test_runner.tl
@@ -7,6 +7,46 @@ local logger = logging.get_logger("tested.test_runner")
 
 local record test_runner end
 
+-- from the indomitable Penlight - MIT
+if not package.searchpath then
+    function package.searchpath (name: string, path: string, sep: string, rep: string): string, string    -- luacheck: ignore
+        if type(name) ~= "string" then
+            error(("bad argument #1 to 'searchpath' (string expected, got %s)"):format(type(path)), 2)
+        end
+        if type(path) ~= "string" then
+            error(("bad argument #2 to 'searchpath' (string expected, got %s)"):format(type(path)), 2)
+        end
+        if sep ~= nil and type(sep) ~= "string" then
+            error(("bad argument #3 to 'searchpath' (string expected, got %s)"):format(type(path)), 2)
+        end
+        if rep ~= nil and type(rep) ~= "string" then
+            error(("bad argument #4 to 'searchpath' (string expected, got %s)"):format(type(path)), 2)
+        end
+        sep = sep or "."
+        rep = rep or _G.package.config:sub(1,1)
+        do
+          local s, e = name:find(sep, nil, true)
+          while s do
+            name = name:sub(1, s-1) .. rep .. name:sub(e+1, -1)
+            s, e = name:find(sep, s + #rep + 1, true)
+          end
+        end
+        local tried = {}
+        for m in path:gmatch('[^;]+') do
+            local nm = m:gsub('?', name)
+            tried[#tried+1] = nm
+            local f = io.open(nm,'r')
+            if f then f:close(); return nm end
+        end
+        return nil, "\tno file '" .. table.concat(tried, "'\n\tno file '") .. "'"
+    end
+end
+
+local function is_c_package(module_name: string): boolean
+   if package.searchpath(module_name, package.cpath) then return true end
+   return false
+end
+
 function test_runner.run_with_cleanup(file_loader: types.FileLoader, test_file: string, options: types.TestRunnerOptions): types.TestedOutput
 
    logger:info("%s: keeping track of pre-loaded packages", test_file)
@@ -20,11 +60,15 @@ function test_runner.run_with_cleanup(file_loader: types.FileLoader, test_file: 
 
    local test_results = test_module:run(test_file, options)
 
-   logger:info("%s: Clearing out any packages that were loaded", test_file)
+   logger:info("%s: Clearing out any Lua packages that were loaded", test_file)
    for package_name, _ in pairs(package.loaded) do
       if not pre_test_loaded_packages[package_name] then
-         logger:debug("%s: Clearing out package: %s", test_file, package_name)
-         package.loaded[package_name] = nil
+         if is_c_package(package_name) then
+            logger:debug("%s: NOT clearing out C module: %s", test_file, package_name)
+         else
+            logger:debug("%s: Clearing out package: %s", test_file, package_name)
+            package.loaded[package_name] = nil
+         end
       end
    end
    collectgarbage()

--- a/src/tested/test_runner.tl
+++ b/src/tested/test_runner.tl
@@ -60,7 +60,7 @@ function test_runner.run_with_cleanup(file_loader: types.FileLoader, test_file: 
 
    local test_results = test_module:run(test_file, options)
 
-   logger:info("%s: Clearing out any Lua packages that were loaded", test_file)
+   logger:info("%s: Clearing out any non-C packages that were loaded", test_file)
    for package_name, _ in pairs(package.loaded) do
       if not pre_test_loaded_packages[package_name] then
          if is_c_package(package_name) then

--- a/tested-0.3.0-1.rockspec
+++ b/tested-0.3.0-1.rockspec
@@ -23,6 +23,7 @@ dependencies = {
 }
 
 test_dependencies = {
+   "lua-cjson", -- needed for one test
    "tl"
 }
 

--- a/tests/execution/c_module_cleanup_test.lua
+++ b/tests/execution/c_module_cleanup_test.lua
@@ -1,0 +1,40 @@
+local tested = require("tested")
+
+local TESTED = "tested"
+local FIXTURE = "tests/execution/cjson_fixture_test.lua"
+
+local function run_with_debug(test_file)
+    local cmd = TESTED .. " -n 0 -f plain -d DEBUG " .. test_file .. " 2>&1"
+    local handle = io.popen(cmd)
+    local out = handle:read("*a")
+    handle:close()
+    return out
+end
+
+tested.test("C modules are not unloaded after test run", function()
+    local out = run_with_debug(FIXTURE)
+    tested.assert({
+        given = "debug output after running a test that requires cjson",
+        should = "contain 'NOT clearing out C module: cjson'",
+        expected = true,
+        actual = out:find("NOT clearing out C module: cjson") ~= nil
+    })
+end)
+
+tested.test("non-C modules are still unloaded after test run", function()
+    local out = run_with_debug(FIXTURE)
+    tested.assert({
+        given = "debug output after running a test that requires cjson",
+        should = "not show cjson being cleared out",
+        expected = false,
+        actual = out:find("Clearing out package: cjson") ~= nil
+    })
+    tested.assert({
+        given = "debug output after running a test that requires cjson",
+        should = "show tested package getting cleared",
+        expected = true,
+        actual = out:find("Clearing out package: tested") ~= nil
+    })
+end)
+
+return tested

--- a/tests/execution/cjson_fixture_test.lua
+++ b/tests/execution/cjson_fixture_test.lua
@@ -1,0 +1,8 @@
+local tested = require("tested")
+local cjson = require("cjson")
+
+tested.test("cjson is available", function()
+    tested.assert({ given = "cjson", should = "be a table", expected = "table", actual = type(lfs) })
+end)
+
+return tested

--- a/tests/execution/cjson_fixture_test.lua
+++ b/tests/execution/cjson_fixture_test.lua
@@ -2,7 +2,7 @@ local tested = require("tested")
 local cjson = require("cjson")
 
 tested.test("cjson is available", function()
-    tested.assert({ given = "cjson", should = "be a table", expected = "table", actual = type(lfs) })
+    tested.assert({ given = "cjson", should = "be a table", expected = "table", actual = type(cjson) })
 end)
 
 return tested


### PR DESCRIPTION
Will now only clear out non-c modules. I feel like this may need to be tunable in the future. Maybe part of the Lua API, perhaps options that can be set at the `tested` level, maybe another cli option? We shall see.

AI Disclosure: AI wrote the unit tests. I wrote the bulk of the code and found the polyfill.

closes #49 