### PR TITLE
Updated the Teal support docs with new beviour

### DIFF
--- a/docs/teal-support.md
+++ b/docs/teal-support.md
@@ -5,11 +5,4 @@
 ## Good to know
 With the way Teal support has been added, `tl.loader()` gets called before running unit tests. This allows Teal files to be `require`'d if they are in the search path. `tl.loader()` adds the Teal package searcher into position two of `package.loaders`, which means if a Teal file and a Lua file are at the same path, the Teal file will be loaded first.
 
-This also means that even if you write your test in Lua, but have it referencing a Teal library, it will use the Teal version of that library. For many situations this might not matter, since they are functionally the same, but it does mean that the Teal version will be re-compiled once per test file, which _could_ cause some performance issues for large Teal test suites. To at least partially mitigate this, `tested` (currently) compiles Teal files, but is set to not type-check them, to offer some time savings.
-
-So yeah, currently two problems around this:
-
-1. Lua files can "accidentally" load Teal modules
-2. Teal files _always_ get re-compiled slowing down unit tests
-
-If this is something you run into and is causing problems (or you have some ideas around it), [let us know](https://github.com/FourierTransformer/tested/issues/46) since we are considering some options there.
+The `package.loaders` also gets backed up and restored between test files, because of this, for each test _file_, any referenced Teal file will get re-compiled which can slow down unit tests. If you're unit testing has begun slowing down your workflows, it might be an idea to write the unit tests in Lua so only (the compiled) Lua files would get loaded.


### PR DESCRIPTION
The docs were still referencing the old way that Teal worked. They've been updated to include how they actually work now.